### PR TITLE
fix: replace hardcoded order params with actual strategy data

### DIFF
--- a/app/routes/orderRoutes.js
+++ b/app/routes/orderRoutes.js
@@ -74,7 +74,7 @@ router.get('/api/v1/orders', OrderController.index);
  *                     type: number
  *                     example: 1.5
  */
-router.get('/api/v1/openOders', OrderController.listThirdPartyOrders);
+router.get('/api/v1/openOrders', OrderController.listThirdPartyOrders);
 
 // Cancel all open orders
 /**

--- a/app/services/awaitService.js
+++ b/app/services/awaitService.js
@@ -61,10 +61,9 @@ class AwaitService {
     });
     const type = 'market';
     const side = 'sell';
-    // For real environment
-    //const orderRes = await exchange.createOrder(strategy.symbol, type, side, strategy.now_quote_total);
-    //for test
-    const orderRes = await exchange.createOrder('EOS/USDT', 'limit', 'sell', 10, 2);
+    const orderRes = await exchange.createOrder(
+      strategy.symbol, type, side, strategy.now_quote_total,
+    );
 
     logger.info(`[order id ] - ${orderRes.id}`);
 
@@ -110,7 +109,7 @@ class AwaitService {
     };
 
     const createOrder = await OrderService.create(newOrder);
-    app.logger.info(`[new order] - ${createOrder._id}`);
+    logger.info(`[new order] - ${createOrder._id}`);
 
     awaitOrder.await_status = AipAwaitModel.STATUS_COMPLETED;
     await awaitOrder.save();

--- a/app/utils/statusCodes.js
+++ b/app/utils/statusCodes.js
@@ -69,6 +69,7 @@ const STATUS_TYPE = {
   AIP_ACCESS_FORBIDDEN: 12005, // Trading module access forbidden
   AIP_INSUFFICIENT_BALANCE: 12006, // Balance is not enough
   AIP_INSUFFICIENT_PURCHASE_AMOUNT: 12007, // the purchase amount is too low
+  AIP_BELOW_MINIMUM_ORDER: 12008, // Order below exchange minimum amount
 
   // Custom status codes for data module (13001-14000)
   DATA_SERVER_BUSY: 13001, // Data module server is busy
@@ -139,6 +140,7 @@ const STATUS_MESSAGE_ZH = {
   [STATUS_TYPE.AIP_ACCESS_FORBIDDEN]: '交易模块禁止访问',
   [STATUS_TYPE.AIP_INSUFFICIENT_BALANCE]: '交易余额不足',
   [STATUS_TYPE.AIP_INSUFFICIENT_PURCHASE_AMOUNT]: '交易数量过少',
+  [STATUS_TYPE.AIP_BELOW_MINIMUM_ORDER]: '订单金额低于交易所最低要求',
 
   // Data module messages
   [STATUS_TYPE.DATA_SERVER_BUSY]: '数据模块服务器繁忙',
@@ -210,6 +212,7 @@ const STATUS_MESSAGE = {
   [STATUS_TYPE.AIP_ACCESS_FORBIDDEN]: 'Trading module access forbidden',
   [STATUS_TYPE.AIP_INSUFFICIENT_BALANCE]: 'Insufficient balance for transaction',
   [STATUS_TYPE.AIP_INSUFFICIENT_PURCHASE_AMOUNT]: 'Insufficient purchase amount',
+  [STATUS_TYPE.AIP_BELOW_MINIMUM_ORDER]: 'Order amount is below exchange minimum',
 
   // Data module messages
   [STATUS_TYPE.DATA_SERVER_BUSY]: 'Data module server is busy',

--- a/docs/plans/2026-02-14-migration-strategy-design.md
+++ b/docs/plans/2026-02-14-migration-strategy-design.md
@@ -150,7 +150,25 @@ All foundation work is done in both projects:
 - **Remaining issues:** [if any]
 -->
 
-(No sessions completed yet)
+### S1 — 2026-02-14: Fix Strategy Execution
+- **Repo:** moow-api-express
+- **Tickets:** 512 fix
+- **What was done:**
+  - Fixed hardcoded buy order params in `strategyService.js` — now uses `strategy.symbol`, type, side, amount, price instead of `'EOS/USDT', 'limit', 'buy', 50, 0.15`
+  - Fixed hardcoded sell order params in `awaitService.js` — now uses `strategy.symbol`, type, side, `strategy.now_quote_total` instead of `'EOS/USDT', 'limit', 'sell', 10, 2`
+  - Added minimum order validation via `exchange.loadMarkets()` — checks both minimum cost and minimum amount against exchange limits
+  - Added `AIP_BELOW_MINIMUM_ORDER (12008)` status code with EN/ZH messages
+  - Fixed `app.logger.info` → `logger.info` bug in `awaitService.js` (leftover from Egg.js migration)
+  - Fixed route typo `/api/v1/openOders` → `/api/v1/openOrders` in `orderRoutes.js`
+  - Updated mock CCXT helper with realistic `loadMarkets` / `markets` data
+  - Added comprehensive unit tests for `awaitService.sellOnThirdParty()` (5 test cases)
+  - Updated `processBuy` tests to verify correct order parameters and minimum validation
+  - All 122 tests passing (13 suites)
+- **PR:** (pending)
+- **Remaining issues:**
+  - Exchange credentials still stored in plaintext (S2 scope — RSA encryption integration)
+  - Value averaging sell strategy not implemented (future scope)
+  - User ownership validation still commented out in `partiallyUpdateStrategy`
 
 ## Best Practices for Working with Claude
 

--- a/docs/plans/2026-02-14-migration-strategy-design.md
+++ b/docs/plans/2026-02-14-migration-strategy-design.md
@@ -164,7 +164,7 @@ All foundation work is done in both projects:
   - Added comprehensive unit tests for `awaitService.sellOnThirdParty()` (5 test cases)
   - Updated `processBuy` tests to verify correct order parameters and minimum validation
   - All 122 tests passing (13 suites)
-- **PR:** (pending)
+- **PR:** #106
 - **Remaining issues:**
   - Exchange credentials still stored in plaintext (S2 scope — RSA encryption integration)
   - Value averaging sell strategy not implemented (future scope)

--- a/tests/helpers/mockCcxt.js
+++ b/tests/helpers/mockCcxt.js
@@ -42,7 +42,24 @@ const createMockExchange = (overrides = {}) => ({
   }),
   fetchOpenOrders: jest.fn().mockResolvedValue([]),
   cancelAllOrders: jest.fn().mockResolvedValue([]),
-  loadMarkets: jest.fn().mockResolvedValue({}),
+  loadMarkets: jest.fn().mockResolvedValue({
+    'BTC/USDT': {
+      symbol: 'BTC/USDT',
+      limits: {
+        amount: { min: 0.00001, max: 9000 },
+        cost: { min: 5, max: undefined },
+      },
+    },
+  }),
+  markets: {
+    'BTC/USDT': {
+      symbol: 'BTC/USDT',
+      limits: {
+        amount: { min: 0.00001, max: 9000 },
+        cost: { min: 5, max: undefined },
+      },
+    },
+  },
   ...overrides,
 });
 

--- a/tests/unit/services/awaitService.test.js
+++ b/tests/unit/services/awaitService.test.js
@@ -1,0 +1,195 @@
+jest.mock('ccxt');
+jest.mock('../../../app/models/aipAwaitModel');
+jest.mock('../../../app/models/aipStrategyModel');
+jest.mock('../../../app/services/orderService');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const ccxt = require('ccxt');
+const AipAwaitModel = require('../../../app/models/aipAwaitModel');
+const AipStrategyModel = require('../../../app/models/aipStrategyModel');
+const OrderService = require('../../../app/services/orderService');
+const AwaitService = require('../../../app/services/awaitService');
+const { createMockExchange, setupCcxtMock } = require('../../helpers/mockCcxt');
+
+// Set model static constants
+AipAwaitModel.STATUS_WAITING = 1;
+AipAwaitModel.STATUS_COMPLETED = 2;
+AipAwaitModel.STATUS_PROCESSING = 3;
+AipAwaitModel.SELL_TYPE_AUTO_SELL = 1;
+AipAwaitModel.SELL_TYPE_DEL_INVEST = 2;
+
+AipStrategyModel.STRATEGY_STATUS_NORMAL = 1;
+AipStrategyModel.STRATEGY_STATUS_CLOSED = 2;
+AipStrategyModel.STRATEGY_STATUS_SOFT_DELETED = 3;
+
+describe('AwaitService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('sellOnThirdParty()', () => {
+    let mockExchange;
+
+    beforeEach(() => {
+      mockExchange = createMockExchange();
+      setupCcxtMock(ccxt, mockExchange);
+      OrderService.create.mockResolvedValue({ _id: 'order-1' });
+    });
+
+    it('should execute sell with correct strategy params', async () => {
+      const strategy = {
+        _id: 'strat-1',
+        exchange: 'binance',
+        key: 'api-key',
+        secret: 'api-secret',
+        symbol: 'BTC/USDT',
+        base: 'USDT',
+        quote: 'BTC',
+        now_quote_total: 0.5,
+        quote_total: 0.5,
+        base_total: 20000,
+        now_base_total: 20000,
+        now_buy_times: 10,
+        buy_times: 10,
+        sell_times: 0,
+        user_market_id: 'market-1',
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      const awaitOrder = {
+        _id: 'await-1',
+        strategy_id: 'strat-1',
+        sell_type: AipAwaitModel.SELL_TYPE_AUTO_SELL,
+        await_status: AipAwaitModel.STATUS_WAITING,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      await AwaitService.sellOnThirdParty(strategy, awaitOrder);
+
+      // Verify createOrder uses strategy params, not hardcoded values
+      expect(mockExchange.createOrder).toHaveBeenCalledWith('BTC/USDT', 'market', 'sell', 0.5);
+      expect(mockExchange.fetchOrder).toHaveBeenCalledWith('mock-order-123', 'BTC/USDT');
+      expect(OrderService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strategy_id: 'strat-1',
+          symbol: 'BTC/USDT',
+          side: 'sell',
+          type: 'market',
+        })
+      );
+      expect(awaitOrder.await_status).toBe(AipAwaitModel.STATUS_COMPLETED);
+      expect(awaitOrder.save).toHaveBeenCalled();
+      expect(strategy.save).toHaveBeenCalled();
+    });
+
+    it('should return early when exchange is undefined', async () => {
+      const strategy = {
+        _id: 'strat-1',
+        exchange: undefined,
+      };
+      const awaitOrder = { save: jest.fn() };
+
+      await AwaitService.sellOnThirdParty(strategy, awaitOrder);
+
+      expect(mockExchange.createOrder).not.toHaveBeenCalled();
+      expect(awaitOrder.save).not.toHaveBeenCalled();
+    });
+
+    it('should close strategy when auto_create is not Y', async () => {
+      const strategy = {
+        _id: 'strat-1',
+        exchange: 'binance',
+        key: 'api-key',
+        secret: 'api-secret',
+        symbol: 'BTC/USDT',
+        now_quote_total: 0.5,
+        quote_total: 0.5,
+        base_total: 20000,
+        now_base_total: 20000,
+        now_buy_times: 10,
+        buy_times: 10,
+        sell_times: 0,
+        user_market_id: 'market-1',
+        auto_create: 'N',
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      const awaitOrder = {
+        sell_type: AipAwaitModel.SELL_TYPE_AUTO_SELL,
+        await_status: AipAwaitModel.STATUS_WAITING,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      await AwaitService.sellOnThirdParty(strategy, awaitOrder);
+
+      expect(strategy.status).toBe(AipStrategyModel.STRATEGY_STATUS_CLOSED);
+      expect(strategy.stop_reason).toBe('profit auto sell');
+    });
+
+    it('should reset counters when auto_create is Y', async () => {
+      const strategy = {
+        _id: 'strat-1',
+        exchange: 'binance',
+        key: 'api-key',
+        secret: 'api-secret',
+        symbol: 'BTC/USDT',
+        now_quote_total: 0.5,
+        quote_total: 0.5,
+        base_total: 20000,
+        now_base_total: 20000,
+        now_buy_times: 10,
+        buy_times: 10,
+        sell_times: 0,
+        user_market_id: 'market-1',
+        auto_create: 'Y',
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      const awaitOrder = {
+        sell_type: AipAwaitModel.SELL_TYPE_AUTO_SELL,
+        await_status: AipAwaitModel.STATUS_WAITING,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      await AwaitService.sellOnThirdParty(strategy, awaitOrder);
+
+      expect(strategy.now_base_total).toBe(0);
+      expect(strategy.now_buy_times).toBe(0);
+      expect(strategy.value_total).toBe(0);
+    });
+
+    it('should soft delete strategy on user delete sell', async () => {
+      const strategy = {
+        _id: 'strat-1',
+        exchange: 'binance',
+        key: 'api-key',
+        secret: 'api-secret',
+        symbol: 'BTC/USDT',
+        now_quote_total: 0.5,
+        quote_total: 0.5,
+        base_total: 20000,
+        now_base_total: 20000,
+        now_buy_times: 10,
+        buy_times: 10,
+        sell_times: 0,
+        user_market_id: 'market-1',
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      const awaitOrder = {
+        sell_type: AipAwaitModel.SELL_TYPE_DEL_INVEST,
+        await_status: AipAwaitModel.STATUS_WAITING,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      await AwaitService.sellOnThirdParty(strategy, awaitOrder);
+
+      expect(strategy.status).toBe(AipStrategyModel.STRATEGY_STATUS_SOFT_DELETED);
+      expect(strategy.stop_reason).toBe('user delete sell');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix hardcoded buy order** in `strategyService.js` — was using `'EOS/USDT', 'limit', 'buy', 50, 0.15` instead of actual strategy parameters (`strategy.symbol`, type, side, amount, price)
- **Fix hardcoded sell order** in `awaitService.js` — was using `'EOS/USDT', 'limit', 'sell', 10, 2` instead of `strategy.symbol`, type, side, `strategy.now_quote_total`
- **Add minimum order validation** via `exchange.loadMarkets()` — checks both minimum cost and minimum amount against exchange limits before placing orders
- **Add `AIP_BELOW_MINIMUM_ORDER` (12008) status code** with EN/ZH messages
- **Fix `app.logger` → `logger` bug** in `awaitService.js` (leftover Egg.js reference that would crash at runtime)
- **Fix route typo** `/api/v1/openOders` → `/api/v1/openOrders` in `orderRoutes.js`

## Test plan
- [x] Updated `processBuy` test to verify `createOrder` receives correct strategy params (not hardcoded)
- [x] Added test for minimum cost validation (`base_limit < exchange min cost`)
- [x] Added test for minimum amount validation (`amount < exchange min amount`)
- [x] Added 5 new `awaitService.sellOnThirdParty()` unit tests covering: correct params, early return, auto-close, auto-restart, and soft delete
- [x] Updated mock CCXT helper with realistic `loadMarkets`/`markets` data
- [x] All 122 tests passing across 13 suites

## Migration context
This is **S1** of the [migration strategy plan](docs/plans/2026-02-14-migration-strategy-design.md). Addresses Known Issues listed in CLAUDE.md under "Core Trading Logic (Critical)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)