### PR TITLE
feat: integrate RSA encryption into strategy execution flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -815,27 +815,17 @@ app.js:
 
 These are documented incomplete features in the codebase. When working on related code, be aware:
 
-### Security (High Priority)
+### Core Trading Logic
 
-- **Exchange credentials plaintext:** `strategyService.js` lines 258-260 and `awaitService.js` line 52 — strategy stores key/secret without encryption. RSA encryption exists in `cryptoUtils.js` but is NOT integrated into the strategy execution flow.
-
-### Core Trading Logic (Critical)
-
-- **Hardcoded test orders:** `strategyService.js` line 314 uses `'EOS/USDT', 'limit', 'buy', 50, 0.15` instead of actual strategy parameters. `awaitService.js` line 67 similarly hardcoded.
-- **No minimum amount validation:** `strategyService.js` line 312 — should enforce exchange minimum (e.g., 5 USDT) via `exchange.loadMarkets()`.
-- **No balance check:** `strategyService.js` line 295 — should verify sufficient balance before ordering.
-- **Value averaging sell not implemented:** `strategyService.js` lines 507-508 — reducing holdings above expected value not built.
+- **Value averaging sell not implemented:** `strategyService.js` — reducing holdings above expected value not built.
 
 ### Auth & User
 
-- **Error logging missing:** `authService.js` lines 182, 269 — catch blocks lack error logging.
-- **Inviter reward incomplete:** `authService.js` line 312 — token reward for referrer not implemented.
-- **moment.js usage:** `authService.js` line 309 — should use dayjs instead.
+- **Inviter reward incomplete:** `authService.js` — token reward for referrer not implemented.
 
 ### Other
 
-- **Route typo:** `/api/v1/openOders` in `orderRoutes.js` should be `/api/v1/openOrders`.
-- **User ownership validation:** `strategyService.js` line 124 — commented out, strategies not verified against requesting user.
+- **User ownership validation:** `strategyService.js` — commented out, strategies not verified against requesting user.
 
 ## Important Notes
 

--- a/app/services/authService.js
+++ b/app/services/authService.js
@@ -14,6 +14,7 @@ const config = require('../../config');
 const EmailService = require('./emailService');
 const PortalEmailInfoModel = require('../models/portalEmailInfoModel');
 const { hashidsEncode, hashidsDecode } = require('../utils/hashidsHandler');
+const logger = require('../utils/logger');
 
 class AuthService {
   // verify captcha
@@ -175,12 +176,10 @@ class AuthService {
       text: `Hello, ${displayName}, to reset your password, please click the link: ${resetPasswordUrl}`,
       html,
     };
-    console.log(html);
     const sendEmailRes = await EmailService.sendEmail(resetPasswordEmail);
 
     if (sendEmailRes.emailStatus === PortalEmailInfoModel.STATUS_FAILED) {
-      // TODO error log
-      console.error('Error sending activation email:', sendEmailRes.desc);
+      logger.error('Error sending retrieve password email:', sendEmailRes.desc);
     }
 
     return {
@@ -266,8 +265,7 @@ class AuthService {
 
     const sendEmailRes = await EmailService.sendEmail(activeEmail);
     if (sendEmailRes.emailStatus === PortalEmailInfoModel.STATUS_FAILED) {
-      // TODO error log
-      console.error('Error sending activation email:', sendEmailRes.desc);
+      logger.error('Error sending activation email:', sendEmailRes.desc);
     }
 
     return {
@@ -306,7 +304,7 @@ class AuthService {
         const now = new Date().getTime();
         const fromTime = now > timeOutAt ? now : timeOutAt;
 
-        const toDate = moment(fromTime).add(1, 'days').toDate();
+        const toDate = dayjs(fromTime).add(1, 'day').toDate();
         refUser.vip_time_out_at = toDate;
 
         // TODO: handle this part after completing assets module

--- a/app/services/awaitService.js
+++ b/app/services/awaitService.js
@@ -2,6 +2,7 @@ const AipAwaitModel = require('../models/aipAwaitModel');
 const AipStrategyModel = require('../models/aipStrategyModel');
 const logger = require('../utils/logger');
 const OrderService = require('./orderService');
+const { decrypt } = require('../utils/cryptoUtils');
 const config = require('../../config');
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const ccxt = require('ccxt');
@@ -49,15 +50,19 @@ class AwaitService {
    * @returns 
    */
   async sellOnThirdParty(strategy, awaitOrder) {
-    //TODO: encrypte and decrypte key and secret
     if (strategy.exchange === undefined) {
       logger.info('[' + strategy._id + '] - exchange is null , call user !');
       return;
     }
+
+    // Decrypt RSA-encrypted exchange credentials
+    const apiKey = decrypt(strategy.key);
+    const secret = decrypt(strategy.secret);
+
     const exchange = new ccxt[strategy.exchange]({
-      apiKey: strategy.key,
-      secret: strategy.secret,
-      timeout: config.exchangeTimeOut
+      apiKey,
+      secret,
+      timeout: config.exchangeTimeOut,
     });
     const type = 'market';
     const side = 'sell';

--- a/app/utils/cryptoUtils.js
+++ b/app/utils/cryptoUtils.js
@@ -29,7 +29,7 @@ const decrypt = (encrypted) => {
     Buffer.from(encrypted, 'base64'),
   );
 
-  return decrypted.toString('base64');
+  return decrypted.toString('utf8');
 };
 
 module.exports = { encrypt, decrypt };

--- a/docs/plans/2026-02-14-migration-strategy-design.md
+++ b/docs/plans/2026-02-14-migration-strategy-design.md
@@ -170,6 +170,28 @@ All foundation work is done in both projects:
   - Value averaging sell strategy not implemented (future scope)
   - User ownership validation still commented out in `partiallyUpdateStrategy`
 
+### S2 — 2026-02-14: RSA Encryption Integration
+- **Repo:** moow-api-express
+- **Tickets:** 609 enhance
+- **What was done:**
+  - Fixed `cryptoUtils.decrypt()` bug — was returning `base64` instead of `utf8`, which would produce garbled API keys
+  - Integrated RSA encryption into `strategyService.createStrategy()` — key/secret are now encrypted before storing to DB
+  - Integrated RSA decryption into `strategyService.processBuy()` and `processSell()` — credentials decrypted before creating CCXT instance
+  - Integrated RSA decryption into `awaitService.sellOnThirdParty()` — same decryption pattern
+  - Fixed `authService.js` error logging — replaced `console.error` with `logger.error` on email send failures (lines 182, 269)
+  - Fixed `authService.js` moment.js usage — replaced `moment(fromTime).add(1, 'days')` with `dayjs(fromTime).add(1, 'day')` (line 309)
+  - Removed stale `console.log(html)` in `authService.sendRetrieveEmail()`
+  - Updated CLAUDE.md known issues — removed all resolved items from S1 and S2
+  - Added encryption/decryption tests for strategyService and awaitService
+  - Added activateUser inviter VIP extension test (validates dayjs fix)
+  - Added sendActivateEmail error logging test
+  - All 126 tests passing (13 suites)
+- **PR:** #107
+- **Remaining issues:**
+  - Value averaging sell strategy not implemented (future scope)
+  - User ownership validation still commented out in `partiallyUpdateStrategy`
+  - Inviter reward token transfer not implemented (pending assets module)
+
 ## Best Practices for Working with Claude
 
 ### Prompt Template


### PR DESCRIPTION
## Summary
- **RSA encryption integrated** into the strategy execution flow: credentials are encrypted on strategy creation and decrypted at execution time in `strategyService` and `awaitService`
- **Fixed `cryptoUtils.decrypt()`** bug: was returning base64-encoded output instead of utf8 plaintext
- **Fixed `authService.js`** issues: replaced `console.error` with `logger.error` (lines 182, 269), replaced `moment.js` with `dayjs` (line 309), removed stale `console.log`
- **Updated CLAUDE.md** known issues section to remove all resolved items from S1 and S2

## Changes

### Security: RSA Encryption Integration
| File | Change |
|------|--------|
| `app/utils/cryptoUtils.js` | Fixed `decrypt()` to return `utf8` instead of `base64` |
| `app/services/strategyService.js` | Encrypt `key`/`secret` in `createStrategy()`, decrypt in `processBuy()` and `processSell()` |
| `app/services/awaitService.js` | Decrypt `key`/`secret` in `sellOnThirdParty()` |

### Auth Fixes
| File | Change |
|------|--------|
| `app/services/authService.js` | Added `logger` import, replaced `console.error` → `logger.error`, replaced `moment()` → `dayjs()`, removed `console.log` |

### Tests
| File | Change |
|------|--------|
| `tests/unit/services/strategyService.test.js` | Mock `cryptoUtils`, verify encrypt on create + decrypt on execute |
| `tests/unit/services/awaitService.test.js` | Mock `cryptoUtils`, verify decrypt + CCXT init with decrypted creds |
| `tests/unit/services/authService.test.js` | Add tests for `activateUser` inviter VIP (dayjs), `sendActivateEmail` error logging |

## Test plan
- [x] All 126 tests passing (13 suites)
- [x] `strategyService.createStrategy()` encrypts key/secret before storing
- [x] `strategyService.processBuy()` decrypts credentials before CCXT init
- [x] `strategyService.processSell()` decrypts credentials before CCXT init
- [x] `awaitService.sellOnThirdParty()` decrypts credentials before CCXT init
- [x] `authService.activateUser()` uses dayjs (not moment) for inviter VIP extension
- [x] `authService` uses `logger.error` instead of `console.error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)