### PR TITLE
feat: complete V0.1 backend implementation

### DIFF
--- a/app/controllers/authController.js
+++ b/app/controllers/authController.js
@@ -4,13 +4,20 @@ const ResponseHandler = require('../utils/responseHandler');
 const { STATUS_TYPE } = require('../utils/statusCodes');
 
 class AuthController {
-
   // user sign up
   async signUp(req, res) {
     const { name, email, password, refCode, captcha } = req.body;
     const sessionCaptcha = req.session.captcha;
     const userIp = req.ip;
-    const user = await AuthService.signUp(name, email, password, refCode, captcha, sessionCaptcha, userIp);
+    const user = await AuthService.signUp(
+      name,
+      email,
+      password,
+      refCode,
+      captcha,
+      sessionCaptcha,
+      userIp
+    );
     return ResponseHandler.success(res, user, STATUS_TYPE.HTTP_CREATED);
   }
 
@@ -57,14 +64,14 @@ class AuthController {
 
   // user logout
   async signout(req, res) {
-    const token = req.headers['token'];
+    const { token } = req.headers;
     await AuthService.signout(token);
     ResponseHandler.success(res);
   }
 
   async resetPassword(req, res) {
     const newPassword = req.body.new_password;
-    const token = req.body.token;
+    const { token } = req.body;
     const resMessage = await AuthService.resetPassword(newPassword, token);
     return ResponseHandler.success(res, resMessage);
   }
@@ -79,14 +86,14 @@ class AuthController {
 
   // activate email
   async activateUser(req, res) {
-    const token = req.body.token;
+    const { token } = req.body;
     const resMessage = await AuthService.activateUser(token);
     return ResponseHandler.success(res, resMessage);
   }
 
   async refresh(req, res) {
     const currentToken = req.headers.token;
-    const userId = req.userId;
+    const { userId } = req;
     const userIp = req.ip;
     const data = await AuthService.refreshToken(currentToken, userId, userIp);
     return ResponseHandler.success(res, data);
@@ -97,7 +104,12 @@ class AuthController {
     const { userEmail, captcha } = req.body;
     const sessionCaptcha = req.session.captcha;
     const userIp = req.ip;
-    const resMessage = await AuthService.sendRetrieveEmail(userEmail, userIp, captcha, sessionCaptcha);
+    const resMessage = await AuthService.sendRetrieveEmail(
+      userEmail,
+      userIp,
+      captcha,
+      sessionCaptcha
+    );
     return ResponseHandler.success(res, resMessage);
   }
 }

--- a/app/controllers/authController.js
+++ b/app/controllers/authController.js
@@ -84,6 +84,14 @@ class AuthController {
     return ResponseHandler.success(res, resMessage);
   }
 
+  async refresh(req, res) {
+    const currentToken = req.headers.token;
+    const userId = req.userId;
+    const userIp = req.ip;
+    const data = await AuthService.refreshToken(currentToken, userId, userIp);
+    return ResponseHandler.success(res, data);
+  }
+
   // send retrieve password email
   async sendRetrieveEmail(req, res) {
     const { userEmail, captcha } = req.body;

--- a/app/controllers/orderController.js
+++ b/app/controllers/orderController.js
@@ -8,6 +8,12 @@ class OrderController {
     return ResponseHandler.success(res, orders);
   }
 
+  async show(req, res) {
+    const { id } = req.params;
+    const order = await OrderService.getOrderById(id);
+    return ResponseHandler.success(res, order);
+  }
+
   async listThirdPartyOrders(req, res) {
     const { exchangeName, symbol, apiKey, secret } = req.query;
     const oders = await OrderService.getThirdPartyOrders(exchangeName, symbol, apiKey, secret);

--- a/app/controllers/orderController.js
+++ b/app/controllers/orderController.js
@@ -8,6 +8,11 @@ class OrderController {
     return ResponseHandler.success(res, orders);
   }
 
+  async statistics(req, res) {
+    const data = await OrderService.getOrderStatistics(req.userId);
+    return ResponseHandler.success(res, data);
+  }
+
   async show(req, res) {
     const { id } = req.params;
     const order = await OrderService.getOrderById(id);

--- a/app/controllers/orderController.js
+++ b/app/controllers/orderController.js
@@ -25,9 +25,14 @@ class OrderController {
     return ResponseHandler.success(res, oders);
   }
 
-  async cancelAllOpenThirdPartyOrders (req, res) {
+  async cancelAllOpenThirdPartyOrders(req, res) {
     const { exchangeName, symbol, apiKey, secret } = req.query;
-    const orders = await OrderService.cancelAllOpenThirdPartyOrders(exchangeName, symbol, apiKey, secret);
+    const orders = await OrderService.cancelAllOpenThirdPartyOrders(
+      exchangeName,
+      symbol,
+      apiKey,
+      secret
+    );
     return ResponseHandler.success(res, orders);
   }
 }

--- a/app/middlewares/authMiddleware.js
+++ b/app/middlewares/authMiddleware.js
@@ -18,7 +18,7 @@ const authMiddleware = async (req, res, next) => {
 
   // Check if token information is complete
   if (!currentPath || !token || !userId) {
-    ResponseHandler.fail(res, STATUS_TYPE.unauthorized, STATUS_TYPE.tokenIllegal);
+    ResponseHandler.fail(res, STATUS_TYPE.HTTP_UNAUTHORIZED, STATUS_TYPE.PORTAL_TOKEN_ILLEGAL);
     return;
   }
 
@@ -27,27 +27,27 @@ const authMiddleware = async (req, res, next) => {
 
   // Check if the document exists
   if (!loginInfoObj) {
-    ResponseHandler.fail(res, STATUS_TYPE.unauthorized, STATUS_TYPE.tokenIllegal);
+    ResponseHandler.fail(res, STATUS_TYPE.HTTP_UNAUTHORIZED, STATUS_TYPE.PORTAL_TOKEN_ILLEGAL);
     return;
   }
 
   // Check if the token has expired
   if ((+new Date() - loginInfoObj.last_access_time) / 1000 > 100000) {
     await AuthService.deleteToken(loginInfoObj);
-    ResponseHandler.fail(res, STATUS_TYPE.unauthorized, STATUS_TYPE.tokenExpired);
+    ResponseHandler.fail(res, STATUS_TYPE.HTTP_UNAUTHORIZED, STATUS_TYPE.PORTAL_TOKEN_EXPIRED);
     return;
   }
 
   // Check if the userId matches the user_id recorded in loginInfoObj
   if (loginInfoObj.user_id.toString() !== userId) {
-    ResponseHandler.fail(res, STATUS_TYPE.unauthorized, STATUS_TYPE.tokenIllegal);
+    ResponseHandler.fail(res, STATUS_TYPE.HTTP_UNAUTHORIZED, STATUS_TYPE.PORTAL_TOKEN_ILLEGAL);
     return;
   }
 
   // Update the latest access time of loginInfoObj
   loginInfoObj.last_access_time = +new Date();
   await AuthService.modifyAccessTime(loginInfoObj);
-  // req.userId = userId;
+  req.userId = userId;
   next();
 };
 

--- a/app/middlewares/validateMiddleware.js
+++ b/app/middlewares/validateMiddleware.js
@@ -13,8 +13,8 @@ const validateParams = (schema) => [
       }));
       return ResponseHandler.fail(
         res,
-        STATUS_TYPE.badRequest,
-        STATUS_TYPE.paramsError,
+        STATUS_TYPE.HTTP_BAD_REQUEST,
+        STATUS_TYPE.COMMON_PARAMS_ERROR,
         paramErrors,
       );
     }

--- a/app/routes/authRoutes.js
+++ b/app/routes/authRoutes.js
@@ -51,11 +51,7 @@ router.get('/api/v1/captcha', AuthController.getCaptcha);
  *       200:
  *         description: User logged in successfully
  */
-router.post(
-  '/api/v1/auth/login',
-  validateParams(signinValidatorSchema),
-  AuthController.signin,
-);
+router.post('/api/v1/auth/login', validateParams(signinValidatorSchema), AuthController.signin);
 
 /**
  * @swagger
@@ -73,7 +69,7 @@ router.delete(
   '/api/v1/auth/logout',
   validateParams(signoutValidatorSchema),
   authMiddleware,
-  AuthController.signout,
+  AuthController.signout
 );
 
 /**
@@ -128,7 +124,7 @@ router.patch('/api/v1/auth/passwordReset', AuthController.resetPassword);
 router.post(
   '/api/v1/auth/activation',
   validateParams(sendActivateEmailValidatorSchema),
-  AuthController.sendActivateEmail,
+  AuthController.sendActivateEmail
 );
 /**
  * @swagger
@@ -161,7 +157,7 @@ router.post(
 router.post(
   '/api/v1/auth/signup',
   validateParams(createUserValidatorSchema),
-  AuthController.signUp,
+  AuthController.signUp
 );
 
 /**
@@ -232,7 +228,7 @@ router.post('/api/v1/auth/refresh', authMiddleware, AuthController.refresh);
 router.post(
   '/api/v1/auth/passwordRecovery',
   validateParams(retrievePasswordValidatorSchema),
-  AuthController.sendRetrieveEmail,
+  AuthController.sendRetrieveEmail
 );
 
 module.exports = router;

--- a/app/routes/authRoutes.js
+++ b/app/routes/authRoutes.js
@@ -193,6 +193,22 @@ router.patch('/api/v1/auth/verification', AuthController.activateUser);
 
 /**
  * @swagger
+ * /api/v1/auth/refresh:
+ *   post:
+ *     summary: Refresh token
+ *     tags:
+ *       - Authentication
+ *     description: Refresh the current session token. Requires valid auth headers.
+ *     responses:
+ *       200:
+ *         description: Token refreshed successfully
+ *       401:
+ *         description: Invalid or expired token
+ */
+router.post('/api/v1/auth/refresh', authMiddleware, AuthController.refresh);
+
+/**
+ * @swagger
  * /api/v1/auth/passwordRecovery:
  *   post:
  *     summary: Password recovery

--- a/app/routes/orderRoutes.js
+++ b/app/routes/orderRoutes.js
@@ -40,6 +40,38 @@ const router = express.Router();
  */
 router.get('/api/v1/orders', authMiddleware, OrderController.index);
 
+// Get order statistics for current user
+/**
+ * @swagger
+ * /api/v1/orders/statistics:
+ *   get:
+ *     summary: Get order statistics
+ *     tags:
+ *       - Orders Management
+ *     description: Get aggregated order statistics for the authenticated user.
+ *     responses:
+ *       200:
+ *         description: Successfully returned order statistics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 total_orders:
+ *                   type: number
+ *                 buy_count:
+ *                   type: number
+ *                 sell_count:
+ *                   type: number
+ *                 total_buy_cost:
+ *                   type: number
+ *                 total_sell_revenue:
+ *                   type: number
+ *                 total_profit:
+ *                   type: number
+ */
+router.get('/api/v1/orders/statistics', authMiddleware, OrderController.statistics);
+
 // Get order detail by id
 /**
  * @swagger

--- a/app/routes/orderRoutes.js
+++ b/app/routes/orderRoutes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const authMiddleware = require('../middlewares/authMiddleware');
 const OrderController = require('../controllers/orderController');
 const router = express.Router();
 
@@ -37,7 +38,7 @@ const router = express.Router();
  *                     type: number
  *                     example: 2
  */
-router.get('/api/v1/orders', OrderController.index);
+router.get('/api/v1/orders', authMiddleware, OrderController.index);
 
 // Fetch all open orders
 /**
@@ -74,7 +75,7 @@ router.get('/api/v1/orders', OrderController.index);
  *                     type: number
  *                     example: 1.5
  */
-router.get('/api/v1/openOrders', OrderController.listThirdPartyOrders);
+router.get('/api/v1/openOrders', authMiddleware, OrderController.listThirdPartyOrders);
 
 // Cancel all open orders
 /**
@@ -100,6 +101,6 @@ router.get('/api/v1/openOrders', OrderController.listThirdPartyOrders);
  *                   type: string
  *                   example: "All open orders have been cancelled successfully"
  */
-router.delete('/api/v1/openOrders', OrderController.cancelAllOpenThirdPartyOrders);
+router.delete('/api/v1/openOrders', authMiddleware, OrderController.cancelAllOpenThirdPartyOrders);
 
 module.exports = router;

--- a/app/routes/orderRoutes.js
+++ b/app/routes/orderRoutes.js
@@ -40,6 +40,29 @@ const router = express.Router();
  */
 router.get('/api/v1/orders', authMiddleware, OrderController.index);
 
+// Get order detail by id
+/**
+ * @swagger
+ * /api/v1/orders/{id}:
+ *   get:
+ *     summary: Get order detail
+ *     tags:
+ *       - Orders Management
+ *     description: Get a single order by its ID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Successfully returned the order detail
+ *       404:
+ *         description: Order not found
+ */
+router.get('/api/v1/orders/:id', authMiddleware, OrderController.show);
+
 // Fetch all open orders
 /**
  * @swagger

--- a/app/routes/orderRoutes.js
+++ b/app/routes/orderRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const authMiddleware = require('../middlewares/authMiddleware');
 const OrderController = require('../controllers/orderController');
+
 const router = express.Router();
 
 // View all orders of a strategy

--- a/app/services/orderService.js
+++ b/app/services/orderService.js
@@ -1,5 +1,6 @@
 const ccxt = require('ccxt');
 const AipOrderModel = require('../models/aipOrderModel');
+const AipStrategyModel = require('../models/aipStrategyModel');
 const CustomError = require('../utils/customError');
 const { STATUS_TYPE } = require('../utils/statusCodes');
 const logger = require('../utils/logger');
@@ -15,6 +16,61 @@ class OrderService {
       .limit(pageSize)
       .lean();
     return { list };
+  }
+
+  async getOrderStatistics(userId) {
+    const strategies = await AipStrategyModel.find({
+      user: userId,
+      status: { $lt: AipStrategyModel.STRATEGY_STATUS_SOFT_DELETED },
+    })
+      .select('_id')
+      .lean();
+
+    const strategyIds = strategies.map((s) => s._id.toString());
+
+    if (strategyIds.length === 0) {
+      return {
+        total_orders: 0,
+        buy_count: 0,
+        sell_count: 0,
+        total_buy_cost: 0,
+        total_sell_revenue: 0,
+        total_profit: 0,
+      };
+    }
+
+    const result = await AipOrderModel.aggregate([
+      { $match: { strategy_id: { $in: strategyIds } } },
+      {
+        $group: {
+          _id: null,
+          total_orders: { $sum: 1 },
+          buy_count: { $sum: { $cond: [{ $eq: ['$side', 'buy'] }, 1, 0] } },
+          sell_count: { $sum: { $cond: [{ $eq: ['$side', 'sell'] }, 1, 0] } },
+          total_buy_cost: {
+            $sum: { $cond: [{ $eq: ['$side', 'buy'] }, '$base_total', 0] },
+          },
+          total_sell_revenue: {
+            $sum: { $cond: [{ $eq: ['$side', 'sell'] }, '$value_total', 0] },
+          },
+          total_profit: { $sum: '$profit' },
+        },
+      },
+    ]);
+
+    if (result.length === 0) {
+      return {
+        total_orders: 0,
+        buy_count: 0,
+        sell_count: 0,
+        total_buy_cost: 0,
+        total_sell_revenue: 0,
+        total_profit: 0,
+      };
+    }
+
+    const { _id, ...stats } = result[0];
+    return stats;
   }
 
   async getOrderById(id) {

--- a/app/services/orderService.js
+++ b/app/services/orderService.js
@@ -98,7 +98,7 @@ class OrderService {
       timeout: config.exchangeTimeOut,
     });
     const openOrders = await exchange.fetchOpenOrders(symbol);
-    openOrders.forEach(order => {
+    openOrders.forEach((order) => {
       const timestamp = new Date(order.timestamp);
       const formattedDate = timestamp.toISOString();
       logger.info(`Order ID: ${order.id}`);

--- a/app/services/orderService.js
+++ b/app/services/orderService.js
@@ -1,5 +1,7 @@
 const ccxt = require('ccxt');
 const AipOrderModel = require('../models/aipOrderModel');
+const CustomError = require('../utils/customError');
+const { STATUS_TYPE } = require('../utils/statusCodes');
 const logger = require('../utils/logger');
 const config = require('../../config');
 
@@ -13,6 +15,14 @@ class OrderService {
       .limit(pageSize)
       .lean();
     return { list };
+  }
+
+  async getOrderById(id) {
+    const order = await AipOrderModel.findById(id).lean();
+    if (!order) {
+      throw new CustomError(STATUS_TYPE.AIP_ORDER_NOT_FOUND, 404);
+    }
+    return order;
   }
 
   async create(order) {

--- a/app/services/strategyService.js
+++ b/app/services/strategyService.js
@@ -1,4 +1,5 @@
 const ccxt = require('ccxt');
+const dayjs = require('dayjs');
 const AipStrategyModel = require('../models/aipStrategyModel');
 const AipAwaitModel = require('../models/aipAwaitModel');
 const { STATUS_TYPE } = require('../utils/statusCodes');
@@ -9,7 +10,6 @@ const AwaitService = require('./awaitService');
 const CustomError = require('../utils/customError');
 const { encrypt, decrypt } = require('../utils/cryptoUtils');
 const config = require('../../config');
-const dayjs = require('dayjs');
 
 class StrategyService {
   /**
@@ -21,7 +21,7 @@ class StrategyService {
     const start = Date.now();
 
     // Do not query strategies with SOFT_DELETED status by default
-    let conditions = {
+    const conditions = {
       user: params.userId,
       status: { $lt: AipStrategyModel.STRATEGY_STATUS_SOFT_DELETED },
     };
@@ -33,7 +33,11 @@ class StrategyService {
     const pageNumber = params.pageNumber || 1;
     const pageSize = params.pageSize || 9999;
 
-    const list = await AipStrategyModel.find(conditions).sort({ created_at: -1 }).skip((pageNumber - 1) * pageSize).limit(pageSize).lean();
+    const list = await AipStrategyModel.find(conditions)
+      .sort({ created_at: -1 })
+      .skip((pageNumber - 1) * pageSize)
+      .limit(pageSize)
+      .lean();
 
     // Calculate the profit rate accroding to the exchange symbol for every strategy
     for (let i = 0, len = list.length; i < len; i++) {
@@ -52,11 +56,14 @@ class StrategyService {
       }
       list[i].price_native = parseFloat(symbolPrice.price_native);
       list[i].profit = list[i].quote_total * symbolPrice.price_native - list[i].base_total;
-      list[i].profit_percentage = parseInt(list[i].base_total, 10) !== 0 ? list[i].profit / list[i].base_total * 100 : 0;
+      list[i].profit_percentage =
+        parseInt(list[i].base_total, 10) !== 0 ? (list[i].profit / list[i].base_total) * 100 : 0;
     }
-  
+
     const total = await AipStrategyModel.countDocuments(conditions);
-    logger.info(`\nQuery List\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${list.length}\n  Response Time: \t${Date.now() - start} ms\n`);
+    logger.info(
+      `\nQuery List\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${list.length}\n  Response Time: \t${Date.now() - start} ms\n`,
+    );
 
     return {
       list,
@@ -82,12 +89,14 @@ class StrategyService {
 
     const symbolList = await SymbolService.getAllSymbols(exSymConditions);
     let symbolPrice = symbolList.list[0];
-    if(symbolPrice) {
+    if (symbolPrice) {
       symbolPrice.total_price = info.quote_total * symbolPrice.price_usd;
     } else {
       symbolPrice = {};
     }
-    logger.info(`\nQuery Details\n  Strategy Id: \t${id}\n  Info Details: \t${info}\n   Response Time: \t${Date.now() - start} ms\n`);
+    logger.info(
+      `\nQuery Details\n  Strategy Id: \t${id}\n  Info Details: \t${info}\n   Response Time: \t${Date.now() - start} ms\n`,
+    );
 
     return { info, symbolPrice };
   }
@@ -99,7 +108,11 @@ class StrategyService {
    */
   async createStrategy(strategy) {
     const start = Date.now();
-    const processedStrategy = { ...strategy, minute:`${parseInt(60 * Math.random(),10)}`, hour:`${parseInt(24 * Math.random(),10)}`};
+    const processedStrategy = {
+      ...strategy,
+      minute: `${parseInt(60 * Math.random(), 10)}`,
+      hour: `${parseInt(24 * Math.random(), 10)}`,
+    };
 
     // Encrypt exchange credentials before storing
     if (processedStrategy.key) {
@@ -113,7 +126,9 @@ class StrategyService {
     await doc.save();
     const strategyId = doc ? doc._id : '';
 
-    logger.info(`\nNew Strategy\n  Strategy Id: \t${JSON.stringify(strategyId)}\n  Strategy Info: \t${JSON.stringify(processedStrategy)}\n  Response Time: \t${Date.now() - start} ms\n`);
+    logger.info(
+      `\nNew Strategy\n  Strategy Id: \t${JSON.stringify(strategyId)}\n  Strategy Info: \t${JSON.stringify(processedStrategy)}\n  Response Time: \t${Date.now() - start} ms\n`,
+    );
 
     return { _id: strategyId };
   }
@@ -123,7 +138,7 @@ class StrategyService {
    * @param params - The strategy data needs to be updated
    * @returns id - Strategies _id
    */
-  async partiallyUpdateStrategy(params){
+  async partiallyUpdateStrategy(params) {
     const start = Date.now();
     const doc = await AipStrategyModel.findById(params._id);
 
@@ -138,11 +153,12 @@ class StrategyService {
     if (typeof params.period !== 'undefined') doc.period = params.period;
     if (typeof params.period_value !== 'undefined') doc.period_value = params.period_value;
     if (typeof params.base_limit !== 'undefined') doc.base_limit = params.base_limit;
-    if (typeof params.stop_profit_percentage !== 'undefined') doc.stop_profit_percentage = params.stop_profit_percentage;
+    if (typeof params.stop_profit_percentage !== 'undefined')
+      doc.stop_profit_percentage = params.stop_profit_percentage;
     if (typeof params.drawdown !== 'undefined') doc.drawdown = params.drawdown;
-    
+
     // For status switching
-    if (typeof params.status !== 'undefined'){
+    if (typeof params.status !== 'undefined') {
       if (AipStrategyModel.STRATEGY_STATUS_NORMAL === parseInt(params.status, 10)) {
         doc.status = AipStrategyModel.STRATEGY_STATUS_NORMAL;
       } else if (AipStrategyModel.STRATEGY_STATUS_CLOSED === parseInt(params.status, 10)) {
@@ -151,7 +167,9 @@ class StrategyService {
     }
 
     await doc.save();
-    logger.info(`\nUpdate Strategy\n  Strategy Id: \t${JSON.stringify(params._id)}\n  Strategy Info: \t${JSON.stringify(params)}\n  Response Time: \t${Date.now() - start} ms\n`);
+    logger.info(
+      `\nUpdate Strategy\n  Strategy Id: \t${JSON.stringify(params._id)}\n  Strategy Info: \t${JSON.stringify(params)}\n  Response Time: \t${Date.now() - start} ms\n`,
+    );
 
     return {
       _id: params._id,
@@ -163,7 +181,7 @@ class StrategyService {
    * @param strategy - The strategy needs to be soft deleted
    * @returns status - Strategy status
    */
-  async deleteStrategy(id){
+  async deleteStrategy(id) {
     const start = Date.now();
     const doc = await AipStrategyModel.findById(id);
 
@@ -182,8 +200,10 @@ class StrategyService {
     // soft delete, update the status
     doc.status = AipStrategyModel.STRATEGY_STATUS_SOFT_DELETED;
     await doc.save();
-    logger.info(`\nDelete Strategy\n  Strategy Id: \t${id}\n  Response Time: \t${Date.now() - start} ms\n`);
-  
+    logger.info(
+      `\nDelete Strategy\n  Strategy Id: \t${id}\n  Response Time: \t${Date.now() - start} ms\n`,
+    );
+
     return {
       status: doc.status,
     };
@@ -201,7 +221,9 @@ class StrategyService {
       minute: now.get('minute').toString(),
     };
     const strategiesArr = await AipStrategyModel.find(conditions).lean();
-    logger.info(`cur day: ${now.get('day')}, hour: ${now.get('hour')}, minite: ${now.get('minute')}`);
+    logger.info(
+      `cur day: ${now.get('day')}, hour: ${now.get('hour')}, minite: ${now.get('minute')}`,
+    );
 
     const results = [];
 
@@ -285,9 +307,7 @@ class StrategyService {
     if (market && market.limits) {
       const minCost = market.limits.cost && market.limits.cost.min;
       if (minCost && strategy.base_limit < minCost) {
-        logger.info(
-          `== order cost ${strategy.base_limit} is below exchange minimum ${minCost}`,
-        );
+        logger.info(`== order cost ${strategy.base_limit} is below exchange minimum ${minCost}`);
         throw new CustomError(STATUS_TYPE.AIP_BELOW_MINIMUM_ORDER);
       }
     }
@@ -330,15 +350,18 @@ class StrategyService {
     if (market && market.limits) {
       const minAmount = market.limits.amount && market.limits.amount.min;
       if (minAmount && amount < minAmount) {
-        logger.info(
-          `== order amount ${amount} is below exchange minimum ${minAmount}`,
-        );
+        logger.info(`== order amount ${amount} is below exchange minimum ${minAmount}`);
         throw new CustomError(STATUS_TYPE.AIP_BELOW_MINIMUM_ORDER);
       }
     }
 
     const orderRes = await exchange.createOrder(
-      strategy.symbol, type, side, amount, price, inParams,
+      strategy.symbol,
+      type,
+      side,
+      amount,
+      price,
+      inParams,
     );
 
     logger.info(`== exchange res order id: ${orderRes.id}`);
@@ -393,20 +416,22 @@ class StrategyService {
     const strategiesArr = await AipStrategyModel.find(conditions).lean();
     for (const strategy of strategiesArr) {
       if (strategy.exchange === undefined) {
-        logger.info('[' + strategy._id + '] - exchange is null , call user !');
+        logger.info(`[${strategy._id}] - exchange is null , call user !`);
         continue;
       }
       const result = await this.executeSell(strategy._id);
-      results.push(result)
+      results.push(result);
     }
     logger.info(`### Round time: ${Date.now() - start}ms`);
-    logger.info('The future has arrived, it just hasn\'t become mainstream yet. Let us lead you into the world of blockchain ahead of time.');
+    logger.info(
+      'The future has arrived, it just hasn\'t become mainstream yet. Let us lead you into the world of blockchain ahead of time.'
+    );
     return results;
   }
 
   /**
    * Method to detect sell signal and execute corresponding operation
-   * @param {strategyId} - The id of the strategy  
+   * @param {strategyId} - The id of the strategy
    * @returns {Object} Result of the sell operation
    */
   async executeSell(strategyId) {
@@ -432,25 +457,27 @@ class StrategyService {
     });
     const tickerRes = await exchange.fetchTicker(strategy.symbol);
     const sell_price = tickerRes.bid;
-    logger.info('[price] - ' + sell_price);
+    logger.info(`[price] - ${sell_price}`);
 
     // check whether profit reaches the stop profit
     const profit = strategy.quote_total * sell_price - strategy.base_total;
-    const profit_percentage = profit / strategy.base_total * 100;
+    const profit_percentage = (profit / strategy.base_total) * 100;
 
-    if(!strategy.stop_profit_percentage) {
+    if (!strategy.stop_profit_percentage) {
       return;
     }
 
     // Did not reach the stop profit point, exiting
     if (profit_percentage < strategy.stop_profit_percentage) {
-      logger.info(`[profit_percentage] - \n Profit Rate: ${profit_percentage}%\n Stop Profit Rate: ${strategy.stop_profit_percentage}%\n Did not reach the stop profit rate, exit`);
+      logger.info(
+        `[profit_percentage] - \n Profit Rate: ${profit_percentage}%\n Stop Profit Rate: ${strategy.stop_profit_percentage}%\n Did not reach the stop profit rate, exit`
+      );
       return {
         strategyId: strategy._id,
-        result: `[profit_percentage] - \n Profit Rate: ${profit_percentage}%\n Stop Profit Rate: ${strategy.stop_profit_percentage}%\n Did not reach the stop profit rate, exit`
+        result: `[profit_percentage] - \n Profit Rate: ${profit_percentage}%\n Stop Profit Rate: ${strategy.stop_profit_percentage}%\n Did not reach the stop profit rate, exit`,
       };
     }
-    if(!strategy.drawdown) {
+    if (!strategy.drawdown) {
       return;
     }
     // Reached the stop profit point, peak not set, proceeding to sell.
@@ -464,20 +491,22 @@ class StrategyService {
     if (strategy.drawdown_status === 'Y' && strategy.drawdown > 0) {
       // If a drawdown is set, compare the current price with the last locked price as a percentage
       // Below the previous price, breaching the drawdown, selling off completely
-      if (strategy.drawdown_price !== 'undefined' && sell_price <= strategy.drawdown_price * (1 - strategy.drawdown / 100)) {
+      if (
+        strategy.drawdown_price !== 'undefined' &&
+        sell_price <= strategy.drawdown_price * (1 - strategy.drawdown / 100)
+      ) {
         logger.info('[drawdown] - Triggering drawdown, selling');
         strategy.sell_price = sell_price;
         return await this.sellout(strategy);
-      } else {
-        // Price is higher than the previous price, resetting the locked price
-        logger.info('[drawdown_price] - Did not trigger peak drawdown, resetting the drawdown price');
-        strategy.drawdown_price = sell_price;
-        await strategy.save();
-        return {
-          strategyId: strategy._id,
-          result: `Did not trigger peak drawdown, resetting the drawdown price. New drawdown price is ${strategy.drawdown_price}.`
-        };
       }
+      // Price is higher than the previous price, resetting the locked price
+      logger.info('[drawdown_price] - Did not trigger peak drawdown, resetting the drawdown price');
+      strategy.drawdown_price = sell_price;
+      await strategy.save();
+      return {
+        strategyId: strategy._id,
+        result: `Did not trigger peak drawdown, resetting the drawdown price. New drawdown price is ${strategy.drawdown_price}.`,
+      };
     }
   }
 
@@ -486,7 +515,7 @@ class StrategyService {
       strategy_id: strategy._id,
       user: strategy.user,
       sell_type: AipAwaitModel.SELL_TYPE_AUTO_SELL,
-      await_status: AipAwaitModel.STATUS_WAITING
+      await_status: AipAwaitModel.STATUS_WAITING,
     };
     const awaitOrder = await AwaitService.createAwait(conditions);
     const id = awaitOrder ? awaitOrder._id : '';
@@ -503,16 +532,18 @@ class StrategyService {
     const conditions = {
       await_status: AipAwaitModel.STATUS_WAITING,
     };
-    const awaitOrders = await AwaitService.index(conditions); 
+    const awaitOrders = await AwaitService.index(conditions);
     logger.info(`### Round time: ${awaitOrders}`);
-    if (awaitOrders.length > 0){
+    if (awaitOrders.length > 0) {
       const updateResult = await AwaitService.update(conditions);
       logger.info(`### Round time: ${JSON.stringify(updateResult)}`);
       for (const awaitorder of awaitOrders) {
         try {
           const strategy = await AipStrategyModel.findById(awaitorder.strategy_id);
           if (!strategy) {
-            logger.error(`Strategy not found for await order ${awaitorder._id}, strategy_id: ${awaitorder.strategy_id}`);
+            logger.error(
+              `Strategy not found for await order ${awaitorder._id}, strategy_id: ${awaitorder.strategy_id}`,
+            );
             continue;
           }
           await AwaitService.sellOnThirdParty(strategy, awaitorder);

--- a/app/services/symbolService.js
+++ b/app/services/symbolService.js
@@ -4,6 +4,7 @@ const csv = require('csv-parser');
 const fs = require('fs');
 const DataExchangeSymbolModel = require('../models/dataExchangeSymbolModel');
 const DataExchangeRateModel = require('../models/dataExchangeRateModel');
+const { priceCache, rateCache, symbolCache } = require('../utils/cacheManager');
 const logger = require('../utils/logger');
 const config = require('../../config');
 
@@ -15,6 +16,14 @@ class SymbolService {
   */
   async getAllSymbols(params) {
     const start = Date.now();
+
+    // Check cache for simple exchange+symbol lookups (strategy list uses this pattern)
+    const cacheKey = `symbols:${JSON.stringify(params)}`;
+    const cached = symbolCache.get(cacheKey);
+    if (cached) {
+      logger.info(`\nQuery List (cached)\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${cached.list.length}\n  Response Time: \t${Date.now() - start} ms\n`);
+      return cached;
+    }
 
     let conditions = {};
 
@@ -51,14 +60,17 @@ class SymbolService {
     const symbolList = await query.collation({ locale: 'zh', numericOrdering: true }).sort({ percent: -1 }).skip((pageNumber - 1) * pageSize).limit(pageSize).lean();
     const total = await DataExchangeSymbolModel.find(conditions).countDocuments();
 
-    logger.info(`\nQuery List\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${symbolList.length}\n  Response Time: \t${Date.now() - start} ms\n`);
-
-    return {
+    const result = {
       list: symbolList,
       pageNumber,
       pageSize,
       total,
     };
+
+    symbolCache.set(cacheKey, result);
+    logger.info(`\nQuery List\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${symbolList.length}\n  Response Time: \t${Date.now() - start} ms\n`);
+
+    return result;
   }
 
   /**
@@ -106,6 +118,12 @@ class SymbolService {
   }
 
   async getPrice(startDate, endDate, exchangeId = 'binance', symbol = 'BTC/USDT', interval = '1d', limit = 1, otherCurrency = 'CNY') {
+    const cacheKey = `price:${exchangeId}:${symbol}:${startDate}:${endDate}:${interval}`;
+    const cached = priceCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
     const exchange = new ccxt[exchangeId]();
     const exchangeUrl = exchange.urls.www || exchange.urls.api;
     // Convert dates to timestamps
@@ -124,6 +142,7 @@ class SymbolService {
     // Process the price data
     await this.processPriceData(allOHLCV, exchangeId, symbol, otherCurrency, exchangeUrl);
 
+    priceCache.set(cacheKey, allOHLCV);
     return allOHLCV;
   }
 
@@ -181,22 +200,30 @@ class SymbolService {
   }
 
   async getUSDToOtherRate(otherCurrency) {
+    const cacheKey = `rate:USD:${otherCurrency}`;
+    const cached = rateCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
     const { apiUrl } = config.currencyRate;
     try {
       let exchangeRate = await DataExchangeRateModel.findOne({ from_currency: 'USD', to_currency: otherCurrency });
       if (exchangeRate) {
+        rateCache.set(cacheKey, exchangeRate.rate);
         return exchangeRate.rate;
       }
       const response = await axios.get(apiUrl);
       const rate = response.data.rates[otherCurrency];
-  
+
       exchangeRate = new DataExchangeRateModel({
         from_currency: 'USD',
         to_currency: otherCurrency,
         rate: rate
       });
-  
+
       await exchangeRate.save();
+      rateCache.set(cacheKey, rate);
       return rate;
     } catch (error) {
       // todo: we need a status code for this

--- a/app/services/symbolService.js
+++ b/app/services/symbolService.js
@@ -10,10 +10,10 @@ const config = require('../../config');
 
 class SymbolService {
   /**
-  * Query a list of all exchange symbols
-  * @param params - The condition params
-  * @returns {list} - List of all the symbols and page number
-  */
+   * Query a list of all exchange symbols
+   * @param params - The condition params
+   * @returns {list} - List of all the symbols and page number
+   */
   async getAllSymbols(params) {
     const start = Date.now();
 
@@ -21,11 +21,13 @@ class SymbolService {
     const cacheKey = `symbols:${JSON.stringify(params)}`;
     const cached = symbolCache.get(cacheKey);
     if (cached) {
-      logger.info(`\nQuery List (cached)\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${cached.list.length}\n  Response Time: \t${Date.now() - start} ms\n`);
+      logger.info(
+        `\nQuery List (cached)\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${cached.list.length}\n  Response Time: \t${Date.now() - start} ms\n`,
+      );
       return cached;
     }
 
-    let conditions = {};
+    const conditions = {};
 
     const pageNumber = params.pageNumber || 1;
     const pageSize = params.pageSize || 9999;
@@ -45,19 +47,29 @@ class SymbolService {
       conditions.quote = quote;
     }
     if (typeof keyword !== 'undefined') {
-      conditions.$or = [{
-        exchange: new RegExp(keyword, 'i'),
-      }, {
-        symbol: new RegExp(keyword, 'i'),
-      }, {
-        base: new RegExp(keyword, 'i'),
-      }, {
-        quote: new RegExp(keyword, 'i'),
-      }];
+      conditions.$or = [
+        {
+          exchange: new RegExp(keyword, 'i'),
+        },
+        {
+          symbol: new RegExp(keyword, 'i'),
+        },
+        {
+          base: new RegExp(keyword, 'i'),
+        },
+        {
+          quote: new RegExp(keyword, 'i'),
+        },
+      ];
     }
 
     const query = DataExchangeSymbolModel.find(conditions);
-    const symbolList = await query.collation({ locale: 'zh', numericOrdering: true }).sort({ percent: -1 }).skip((pageNumber - 1) * pageSize).limit(pageSize).lean();
+    const symbolList = await query
+      .collation({ locale: 'zh', numericOrdering: true })
+      .sort({ percent: -1 })
+      .skip((pageNumber - 1) * pageSize)
+      .limit(pageSize)
+      .lean();
     const total = await DataExchangeSymbolModel.find(conditions).countDocuments();
 
     const result = {
@@ -68,28 +80,32 @@ class SymbolService {
     };
 
     symbolCache.set(cacheKey, result);
-    logger.info(`\nQuery List\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${symbolList.length}\n  Response Time: \t${Date.now() - start} ms\n`);
+    logger.info(
+      `\nQuery List\n  Params: \t${JSON.stringify(params)}\n  Return Amount: \t${symbolList.length}\n  Response Time: \t${Date.now() - start} ms\n`,
+    );
 
     return result;
   }
 
   /**
-  * Query exchange platform information by id
-  * @param {string} id - The id of symbol
-  * @returns {string} info - The symbol info details
-  */
+   * Query exchange platform information by id
+   * @param {string} id - The id of symbol
+   * @returns {string} info - The symbol info details
+   */
   async getSymbolById(id) {
     const start = Date.now();
     const info = await DataExchangeSymbolModel.findById(id);
 
-    logger.info(`\nQuery Details\n  Symbol Id: \t${id}\n  Info Details: \t${JSON.stringify(info)}\n    Response Time: \t${Date.now() - start} ms\n`);
-    
+    logger.info(
+      `\nQuery Details\n  Symbol Id: \t${id}\n  Info Details: \t${JSON.stringify(info)}\n    Response Time: \t${Date.now() - start} ms\n`,
+    );
+
     return info;
   }
 
   // For test
   async createSymbol(params) {
-    let processedSymbol = {};
+    const processedSymbol = {};
 
     if (params.key !== undefined) processedSymbol.key = params.key;
     if (params.exchange !== undefined) processedSymbol.exchange = params.exchange;
@@ -99,14 +115,14 @@ class SymbolService {
     if (params.price_usd !== undefined) processedSymbol.price_usd = params.price_usd;
     if (params.price_btc !== undefined) processedSymbol.price_btc = params.price_btc;
     if (params.price_native !== undefined) processedSymbol.price_native = params.price_native;
-    
+
     if (params.vol_cny !== undefined) processedSymbol.vol_cny = params.vol_cny;
     if (params.vol_usd !== undefined) processedSymbol.vol_usd = params.vol_usd;
     if (params.vol_btc !== undefined) processedSymbol.vol_btc = params.vol_btc;
     if (params.vol_native !== undefined) processedSymbol.vol_native = params.vol_native;
     if (params.trade_vol !== undefined) processedSymbol.trade_vol = params.trade_vol;
     if (params.percent !== undefined) processedSymbol.percent = params.percent;
-    
+
     if (params.base !== undefined) processedSymbol.base = params.base;
     if (params.quote !== undefined) processedSymbol.quote = params.quote;
     if (params.exchange_url !== undefined) processedSymbol.exchange_url = params.exchange_url;
@@ -117,7 +133,15 @@ class SymbolService {
     return { newExchangeSymbol };
   }
 
-  async getPrice(startDate, endDate, exchangeId = 'binance', symbol = 'BTC/USDT', interval = '1d', limit = 1, otherCurrency = 'CNY') {
+  async getPrice(
+    startDate,
+    endDate,
+    exchangeId = 'binance',
+    symbol = 'BTC/USDT',
+    interval = '1d',
+    limit = 1,
+    otherCurrency = 'CNY',
+  ) {
     const cacheKey = `price:${exchangeId}:${symbol}:${startDate}:${endDate}:${interval}`;
     const cached = priceCache.get(cacheKey);
     if (cached) {
@@ -146,22 +170,22 @@ class SymbolService {
     return allOHLCV;
   }
 
-  async processPriceData(allOHLCV, exchange, symbol, otherCurrency, exchangeUrl){
+  async processPriceData(allOHLCV, exchange, symbol, otherCurrency, exchangeUrl) {
     const [base, quote] = symbol.split('/');
-    
-    let usdtRate = 1; 
+
+    let usdtRate = 1;
     if (quote !== 'USDT') {
       const ticker = await exchange.fetchTicker(`${symbol}/USDT`);
       usdtRate = ticker.last;
-    }   
+    }
 
     const usdToOtherRate = await this.getUSDToOtherRate(otherCurrency);
-    const records = allOHLCV.map(candle => {
+    const records = allOHLCV.map((candle) => {
       const [timestamp, open, high, low, close, volume] = candle;
       return {
         key: `${exchange}_${symbol}`,
-        exchange: exchange,
-        symbol: symbol,
+        exchange,
+        symbol,
         open: open.toFixed(2).toString(),
         high: high.toFixed(2).toString(),
         low: low.toFixed(2).toString(),
@@ -177,15 +201,15 @@ class SymbolService {
         vol_native: '', // Assuming USD is the native volume here
         trade_vol: (volume / close).toFixed(4).toString(), // Volume in terms of amount of BTC
         percent: '',
-        base: base,
-        quote: quote,
+        base,
+        quote,
         exchange_url: exchangeUrl,
         on_time: new Date(timestamp + 8 * 60 * 60 * 1000),
         status: '1',
       };
     });
     // Use bulkWrite with upsert option
-    const bulkOps = records.map(record => ({
+    const bulkOps = records.map((record) => ({
       updateOne: {
         filter: { key: record.key, on_time: record.on_time },
         update: { $setOnInsert: record },
@@ -195,7 +219,7 @@ class SymbolService {
 
     await DataExchangeSymbolModel.bulkWrite(bulkOps);
     logger.info(`Successfully inserted ${records.length} records for ${symbol}`);
-    
+
     return true;
   }
 
@@ -208,7 +232,10 @@ class SymbolService {
 
     const { apiUrl } = config.currencyRate;
     try {
-      let exchangeRate = await DataExchangeRateModel.findOne({ from_currency: 'USD', to_currency: otherCurrency });
+      let exchangeRate = await DataExchangeRateModel.findOne({
+        from_currency: 'USD',
+        to_currency: otherCurrency,
+      });
       if (exchangeRate) {
         rateCache.set(cacheKey, exchangeRate.rate);
         return exchangeRate.rate;
@@ -219,7 +246,7 @@ class SymbolService {
       exchangeRate = new DataExchangeRateModel({
         from_currency: 'USD',
         to_currency: otherCurrency,
-        rate: rate
+        rate,
       });
 
       await exchangeRate.save();
@@ -232,7 +259,12 @@ class SymbolService {
   }
 
   // Function to import CSV data
-  async loadPriceData(filePath, exchangeId = 'binance', symbol = 'BTC/USDT', otherCurrency = 'CNY') {
+  async loadPriceData(
+    filePath,
+    exchangeId = 'binance',
+    symbol = 'BTC/USDT',
+    otherCurrency = 'CNY',
+  ) {
     const records = [];
     const exchange = new ccxt[exchangeId]();
     const exchangeUrl = exchange.urls.www || exchange.urls.api;
@@ -256,7 +288,13 @@ class SymbolService {
         }
       })
       .on('end', async () => {
-        const newSymbolData = await this.processPriceData(records, exchangeId, symbol, otherCurrency, exchangeUrl);
+        const newSymbolData = await this.processPriceData(
+          records,
+          exchangeId,
+          symbol,
+          otherCurrency,
+          exchangeUrl,
+        );
       });
   }
 }

--- a/app/utils/cacheManager.js
+++ b/app/utils/cacheManager.js
@@ -1,0 +1,7 @@
+const NodeCache = require('node-cache');
+
+const priceCache = new NodeCache({ stdTTL: 60, checkperiod: 120 });
+const rateCache = new NodeCache({ stdTTL: 3600, checkperiod: 600 });
+const symbolCache = new NodeCache({ stdTTL: 300, checkperiod: 60 });
+
+module.exports = { priceCache, rateCache, symbolCache };

--- a/app/utils/statusCodes.js
+++ b/app/utils/statusCodes.js
@@ -70,6 +70,7 @@ const STATUS_TYPE = {
   AIP_INSUFFICIENT_BALANCE: 12006, // Balance is not enough
   AIP_INSUFFICIENT_PURCHASE_AMOUNT: 12007, // the purchase amount is too low
   AIP_BELOW_MINIMUM_ORDER: 12008, // Order below exchange minimum amount
+  AIP_ORDER_NOT_FOUND: 12009, // Order not found
 
   // Custom status codes for data module (13001-14000)
   DATA_SERVER_BUSY: 13001, // Data module server is busy
@@ -141,6 +142,7 @@ const STATUS_MESSAGE_ZH = {
   [STATUS_TYPE.AIP_INSUFFICIENT_BALANCE]: '交易余额不足',
   [STATUS_TYPE.AIP_INSUFFICIENT_PURCHASE_AMOUNT]: '交易数量过少',
   [STATUS_TYPE.AIP_BELOW_MINIMUM_ORDER]: '订单金额低于交易所最低要求',
+  [STATUS_TYPE.AIP_ORDER_NOT_FOUND]: '订单未找到',
 
   // Data module messages
   [STATUS_TYPE.DATA_SERVER_BUSY]: '数据模块服务器繁忙',
@@ -213,6 +215,7 @@ const STATUS_MESSAGE = {
   [STATUS_TYPE.AIP_INSUFFICIENT_BALANCE]: 'Insufficient balance for transaction',
   [STATUS_TYPE.AIP_INSUFFICIENT_PURCHASE_AMOUNT]: 'Insufficient purchase amount',
   [STATUS_TYPE.AIP_BELOW_MINIMUM_ORDER]: 'Order amount is below exchange minimum',
+  [STATUS_TYPE.AIP_ORDER_NOT_FOUND]: 'Order not found',
 
   // Data module messages
   [STATUS_TYPE.DATA_SERVER_BUSY]: 'Data module server is busy',

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "lodash": "^4.17.21",
         "mongoose": "^8.4.0",
         "morgan": "^1.10.0",
+        "node-cache": "^5.1.2",
         "node-cron": "^3.0.3",
         "nodemailer": "^6.9.13",
         "svg-captcha": "^1.4.0",
@@ -11367,6 +11368,27 @@
       },
       "engines": {
         "node": ">=12.22.0"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-cache/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/node-cron": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lodash": "^4.17.21",
     "mongoose": "^8.4.0",
     "morgan": "^1.10.0",
+    "node-cache": "^5.1.2",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.13",
     "svg-captcha": "^1.4.0",

--- a/tests/integration/order.test.js
+++ b/tests/integration/order.test.js
@@ -157,9 +157,7 @@ describe('Order API Integration', () => {
       const userId = new mongoose.Types.ObjectId(auth.user_id);
 
       // Create a strategy belonging to this user
-      const strategy = await AipStrategyModel.create(
-        createStrategyData({ user: userId }),
-      );
+      const strategy = await AipStrategyModel.create(createStrategyData({ user: userId }));
 
       // Create orders for this strategy
       await AipOrderModel.create(
@@ -168,7 +166,7 @@ describe('Order API Integration', () => {
           side: 'buy',
           base_total: 100,
           profit: 0,
-        }),
+        })
       );
       await AipOrderModel.create(
         createOrderData({
@@ -176,7 +174,7 @@ describe('Order API Integration', () => {
           side: 'buy',
           base_total: 200,
           profit: 0,
-        }),
+        })
       );
 
       const res = await request(app)

--- a/tests/integration/order.test.js
+++ b/tests/integration/order.test.js
@@ -95,4 +95,39 @@ describe('Order API Integration', () => {
       expect(res.body.data.list).toBeDefined();
     });
   });
+
+  describe('GET /api/v1/orders/:id', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const orderId = new mongoose.Types.ObjectId().toString();
+      const res = await request(app).get(`/api/v1/orders/${orderId}`);
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return order detail when found', async () => {
+      const auth = await createAuthHeaders();
+      const order = await AipOrderModel.create(createOrderData({ side: 'buy' }));
+
+      const res = await request(app)
+        .get(`/api/v1/orders/${order._id}`)
+        .set('token', auth.token)
+        .set('user_id', auth.user_id);
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data._id).toBe(order._id.toString());
+    });
+
+    it('should return 404 when order not found', async () => {
+      const auth = await createAuthHeaders();
+      const fakeId = new mongoose.Types.ObjectId().toString();
+
+      const res = await request(app)
+        .get(`/api/v1/orders/${fakeId}`)
+        .set('token', auth.token)
+        .set('user_id', auth.user_id);
+
+      expect(res.status).toBe(404);
+    });
+  });
 });

--- a/tests/unit/middlewares/authMiddleware.test.js
+++ b/tests/unit/middlewares/authMiddleware.test.js
@@ -37,7 +37,7 @@ describe('authMiddleware', () => {
     expect(ResponseHandler.fail).toHaveBeenCalledWith(
       res,
       STATUS_TYPE.HTTP_UNAUTHORIZED,
-      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL,
+      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL
     );
     expect(next).not.toHaveBeenCalled();
   });
@@ -50,7 +50,7 @@ describe('authMiddleware', () => {
     expect(ResponseHandler.fail).toHaveBeenCalledWith(
       res,
       STATUS_TYPE.HTTP_UNAUTHORIZED,
-      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL,
+      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL
     );
     expect(next).not.toHaveBeenCalled();
   });
@@ -64,7 +64,7 @@ describe('authMiddleware', () => {
     expect(ResponseHandler.fail).toHaveBeenCalledWith(
       res,
       STATUS_TYPE.HTTP_UNAUTHORIZED,
-      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL,
+      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL
     );
     expect(next).not.toHaveBeenCalled();
   });
@@ -85,7 +85,7 @@ describe('authMiddleware', () => {
     expect(ResponseHandler.fail).toHaveBeenCalledWith(
       res,
       STATUS_TYPE.HTTP_UNAUTHORIZED,
-      STATUS_TYPE.PORTAL_TOKEN_EXPIRED,
+      STATUS_TYPE.PORTAL_TOKEN_EXPIRED
     );
     expect(next).not.toHaveBeenCalled();
   });
@@ -102,7 +102,7 @@ describe('authMiddleware', () => {
     expect(ResponseHandler.fail).toHaveBeenCalledWith(
       res,
       STATUS_TYPE.HTTP_UNAUTHORIZED,
-      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL,
+      STATUS_TYPE.PORTAL_TOKEN_ILLEGAL
     );
     expect(next).not.toHaveBeenCalled();
   });

--- a/tests/unit/services/authService.test.js
+++ b/tests/unit/services/authService.test.js
@@ -348,6 +348,64 @@ describe('AuthService', () => {
     });
   });
 
+  describe('refreshToken()', () => {
+    it('should throw when token not found', async () => {
+      PortalTokenModel.findOne.mockResolvedValue(null);
+
+      await expect(
+        AuthService.refreshToken('bad-token', 'user-id', '127.0.0.1'),
+      ).rejects.toThrow();
+    });
+
+    it('should throw when user_id does not match', async () => {
+      PortalTokenModel.findOne.mockResolvedValue({
+        _id: 'token-id',
+        user_id: { toString: () => 'different-user' },
+        last_access_time: Date.now(),
+      });
+
+      await expect(
+        AuthService.refreshToken('token', 'user-id', '127.0.0.1'),
+      ).rejects.toThrow();
+    });
+
+    it('should throw when token is expired', async () => {
+      const expiredTime = Date.now() - 200000 * 1000;
+      PortalTokenModel.findOne.mockResolvedValue({
+        _id: 'token-id',
+        user_id: { toString: () => 'user-id' },
+        last_access_time: expiredTime,
+      });
+      PortalTokenModel.deleteOne.mockResolvedValue({});
+
+      await expect(
+        AuthService.refreshToken('token', 'user-id', '127.0.0.1'),
+      ).rejects.toThrow();
+    });
+
+    it('should delete old token and return new token on success', async () => {
+      PortalTokenModel.findOne.mockResolvedValue({
+        _id: 'token-id',
+        user_id: { toString: () => 'user-id' },
+        last_access_time: Date.now(),
+      });
+      PortalTokenModel.deleteOne.mockResolvedValue({});
+      PortalUserModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'user-id',
+          email: 'test@test.com',
+          nick_name: 'Test',
+        }),
+      });
+      jest.spyOn(AuthService, '_getToken').mockResolvedValue('new-token');
+
+      const result = await AuthService.refreshToken('old-token', 'user-id', '127.0.0.1');
+
+      expect(PortalTokenModel.deleteOne).toHaveBeenCalledWith({ _id: 'token-id' });
+      expect(result.token).toBe('new-token');
+    });
+  });
+
   describe('sendActivateEmail()', () => {
     it('should log error when email sending fails', async () => {
       const mockUser = {

--- a/tests/unit/services/authService.test.js
+++ b/tests/unit/services/authService.test.js
@@ -334,9 +334,7 @@ describe('AuthService', () => {
       expect(refUser.save).toHaveBeenCalled();
       expect(refUser.vip_time_out_at).toBeInstanceOf(Date);
       // The new date should be 1 day after 2026-03-01
-      expect(refUser.vip_time_out_at.getTime()).toBeGreaterThan(
-        new Date('2026-03-01').getTime(),
-      );
+      expect(refUser.vip_time_out_at.getTime()).toBeGreaterThan(new Date('2026-03-01').getTime());
     });
 
     it('should throw when activation token not found', async () => {
@@ -352,9 +350,7 @@ describe('AuthService', () => {
     it('should throw when token not found', async () => {
       PortalTokenModel.findOne.mockResolvedValue(null);
 
-      await expect(
-        AuthService.refreshToken('bad-token', 'user-id', '127.0.0.1'),
-      ).rejects.toThrow();
+      await expect(AuthService.refreshToken('bad-token', 'user-id', '127.0.0.1')).rejects.toThrow();
     });
 
     it('should throw when user_id does not match', async () => {
@@ -364,9 +360,7 @@ describe('AuthService', () => {
         last_access_time: Date.now(),
       });
 
-      await expect(
-        AuthService.refreshToken('token', 'user-id', '127.0.0.1'),
-      ).rejects.toThrow();
+      await expect(AuthService.refreshToken('token', 'user-id', '127.0.0.1')).rejects.toThrow();
     });
 
     it('should throw when token is expired', async () => {
@@ -378,9 +372,7 @@ describe('AuthService', () => {
       });
       PortalTokenModel.deleteOne.mockResolvedValue({});
 
-      await expect(
-        AuthService.refreshToken('token', 'user-id', '127.0.0.1'),
-      ).rejects.toThrow();
+      await expect(AuthService.refreshToken('token', 'user-id', '127.0.0.1')).rejects.toThrow();
     });
 
     it('should delete old token and return new token on success', async () => {
@@ -430,7 +422,7 @@ describe('AuthService', () => {
 
       expect(logger.error).toHaveBeenCalledWith(
         'Error sending activation email:',
-        'SMTP connection error',
+        'SMTP connection error'
       );
       expect(result.message).toBe('Activation email will be sent!');
     });

--- a/tests/unit/services/orderService.test.js
+++ b/tests/unit/services/orderService.test.js
@@ -7,10 +7,33 @@ jest.mock('../../../app/utils/logger', () => ({
 
 const AipOrderModel = require('../../../app/models/aipOrderModel');
 const OrderService = require('../../../app/services/orderService');
+const CustomError = require('../../../app/utils/customError');
 
 describe('OrderService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('getOrderById()', () => {
+    it('should return order when found', async () => {
+      const mockOrder = { _id: 'order-1', strategy_id: 'strat-1', side: 'buy' };
+      AipOrderModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockOrder),
+      });
+
+      const result = await OrderService.getOrderById('order-1');
+
+      expect(AipOrderModel.findById).toHaveBeenCalledWith('order-1');
+      expect(result).toEqual(mockOrder);
+    });
+
+    it('should throw CustomError when order not found', async () => {
+      AipOrderModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(OrderService.getOrderById('nonexistent')).rejects.toThrow(CustomError);
+    });
   });
 
   describe('create()', () => {

--- a/tests/unit/services/strategyService.test.js
+++ b/tests/unit/services/strategyService.test.js
@@ -252,7 +252,7 @@ describe('StrategyService', () => {
         expect.objectContaining({
           strategy_id: 'strat-1',
           user: 'user-1',
-          sell_type: AipAwaitModel.SELL_TYPE_AUTO_SELL,
+          sell_type: AipAwaitModel.SELL_TYPE_DEL_INVEST,
           await_status: AipAwaitModel.STATUS_WAITING,
         })
       );
@@ -624,6 +624,50 @@ describe('StrategyService', () => {
       expect(StrategyService.executeBuy).toHaveBeenCalledWith(
         expect.objectContaining({ _id: 'strat-daily' })
       );
+    });
+  });
+
+  describe('sellAllOrders()', () => {
+    it('should continue processing when one await order fails', async () => {
+      const awaitOrders = [
+        { _id: 'await-1', strategy_id: 'strat-1' },
+        { _id: 'await-2', strategy_id: 'strat-2' },
+      ];
+
+      AwaitService.index.mockResolvedValue(awaitOrders);
+      AwaitService.update.mockResolvedValue({});
+
+      const strategy1 = { _id: 'strat-1', exchange: 'binance' };
+      const strategy2 = { _id: 'strat-2', exchange: 'binance' };
+
+      AipStrategyModel.findById
+        .mockResolvedValueOnce(strategy1)
+        .mockResolvedValueOnce(strategy2);
+
+      // First sell fails, second succeeds
+      AwaitService.sellOnThirdParty
+        .mockRejectedValueOnce(new Error('Exchange error'))
+        .mockResolvedValueOnce({});
+
+      await StrategyService.sellAllOrders();
+
+      // Both should be attempted
+      expect(AipStrategyModel.findById).toHaveBeenCalledTimes(2);
+      expect(AwaitService.sellOnThirdParty).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip when strategy not found for await order', async () => {
+      const awaitOrders = [
+        { _id: 'await-1', strategy_id: 'strat-missing' },
+      ];
+
+      AwaitService.index.mockResolvedValue(awaitOrders);
+      AwaitService.update.mockResolvedValue({});
+      AipStrategyModel.findById.mockResolvedValue(null);
+
+      await StrategyService.sellAllOrders();
+
+      expect(AwaitService.sellOnThirdParty).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/services/strategyService.test.js
+++ b/tests/unit/services/strategyService.test.js
@@ -306,7 +306,7 @@ describe('StrategyService', () => {
         expect.objectContaining({
           apiKey: 'api-key',
           secret: 'api-secret',
-        }),
+        })
       );
       expect(mockExchange.fetchTicker).toHaveBeenCalledWith('BTC/USDT');
       expect(mockExchange.loadMarkets).toHaveBeenCalled();
@@ -317,7 +317,7 @@ describe('StrategyService', () => {
         'buy',
         expect.any(String),
         50000,
-        {},
+        {}
       );
       expect(OrderService.create).toHaveBeenCalled();
       expect(strategy.buy_times).toBe(6);
@@ -640,9 +640,7 @@ describe('StrategyService', () => {
       const strategy1 = { _id: 'strat-1', exchange: 'binance' };
       const strategy2 = { _id: 'strat-2', exchange: 'binance' };
 
-      AipStrategyModel.findById
-        .mockResolvedValueOnce(strategy1)
-        .mockResolvedValueOnce(strategy2);
+      AipStrategyModel.findById.mockResolvedValueOnce(strategy1).mockResolvedValueOnce(strategy2);
 
       // First sell fails, second succeeds
       AwaitService.sellOnThirdParty
@@ -657,9 +655,7 @@ describe('StrategyService', () => {
     });
 
     it('should skip when strategy not found for await order', async () => {
-      const awaitOrders = [
-        { _id: 'await-1', strategy_id: 'strat-missing' },
-      ];
+      const awaitOrders = [{ _id: 'await-1', strategy_id: 'strat-missing' }];
 
       AwaitService.index.mockResolvedValue(awaitOrders);
       AwaitService.update.mockResolvedValue({});

--- a/tests/unit/utils/cacheManager.test.js
+++ b/tests/unit/utils/cacheManager.test.js
@@ -1,0 +1,44 @@
+const { priceCache, rateCache, symbolCache } = require('../../../app/utils/cacheManager');
+
+describe('cacheManager', () => {
+  afterEach(() => {
+    priceCache.flushAll();
+    rateCache.flushAll();
+    symbolCache.flushAll();
+  });
+
+  it('should set and get values from priceCache', () => {
+    priceCache.set('test-key', { price: 50000 });
+    const result = priceCache.get('test-key');
+    expect(result).toEqual({ price: 50000 });
+  });
+
+  it('should return undefined for missing keys', () => {
+    const result = priceCache.get('nonexistent');
+    expect(result).toBeUndefined();
+  });
+
+  it('should set and get values from rateCache', () => {
+    rateCache.set('rate:USD:CNY', 7.25);
+    expect(rateCache.get('rate:USD:CNY')).toBe(7.25);
+  });
+
+  it('should set and get values from symbolCache', () => {
+    symbolCache.set('symbols:test', { list: [{ symbol: 'BTC/USDT' }] });
+    const result = symbolCache.get('symbols:test');
+    expect(result.list).toHaveLength(1);
+  });
+
+  it('should respect TTL and expire entries', async () => {
+    // Create a cache with 1 second TTL for testing
+    const NodeCache = require('node-cache');
+    const testCache = new NodeCache({ stdTTL: 1, checkperiod: 1 });
+
+    testCache.set('temp', 'value');
+    expect(testCache.get('temp')).toBe('value');
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(testCache.get('temp')).toBeUndefined();
+  });
+});

--- a/tests/unit/utils/cacheManager.test.js
+++ b/tests/unit/utils/cacheManager.test.js
@@ -38,7 +38,9 @@ describe('cacheManager', () => {
     expect(testCache.get('temp')).toBe('value');
 
     // Wait for TTL to expire
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1100);
+    });
     expect(testCache.get('temp')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- **Fix middleware STATUS_TYPE bugs**: Corrected non-existent `STATUS_TYPE` property references in `authMiddleware` and `validateMiddleware` that caused all auth/validation errors to return 500 instead of 401/400. Uncommented `req.userId` assignment.
- **Add auth to order routes**: Applied `authMiddleware` to all order endpoints that were previously unprotected.
- **Add order detail endpoint**: `GET /api/v1/orders/:id` with proper 404 handling via `CustomError`.
- **Add order statistics endpoint**: `GET /api/v1/orders/statistics` aggregates orders across user's strategies (total orders, buy/sell counts, costs, revenue, profit).
- **Add JWT refresh endpoint**: `POST /api/v1/auth/refresh` validates current token, deletes it, and issues a new session token.
- **Add price query cache**: In-memory TTL cache via `node-cache` for symbol queries (300s), price data (60s), and exchange rates (3600s).
- **Fix strategy soft delete sell_type**: Changed `SELL_TYPE_AUTO_SELL` → `SELL_TYPE_DEL_INVEST` in `deleteStrategy()` and added error handling in `sellAllOrders()` loop.

## Test plan

- [x] All 152 tests pass across 14 suites (unit + integration)
- [x] Verify unauthenticated requests to `/api/v1/orders` return 401
- [x] Verify `GET /api/v1/orders/:id` returns order detail or 404
- [x] Verify `GET /api/v1/orders/statistics` returns correct aggregated stats
- [x] Verify `POST /api/v1/auth/refresh` returns new token
- [x] Verify cache hit/miss behavior in symbol and price queries
- [x] Verify `deleteStrategy` await record uses `SELL_TYPE_DEL_INVEST` (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)