### PR TITLE
fix: address critical value averaging and data accuracy bugs

### DIFF
--- a/app/models/aipAwaitModel.js
+++ b/app/models/aipAwaitModel.js
@@ -9,6 +9,7 @@ const AipAwaitSchema = new mongoose.Schema(
     await_status: { type: Number, trim: true }, // 1: Waiting 2: Completed 3: Processing
     sell_type: { type: Number, trim: true }, // 1: Automatic sell 2: Delete investment
     sell_price: { type: Number, default: 0 }, // Sell price
+    sell_amount: { type: Number, default: 0 }, // Partial sell amount (for intelligent strategy value averaging)
 
     user_market_id: { type: String, trim: true }, // ID of the market key set by the user
     exchange: { type: String, trim: true }, // Market

--- a/app/models/aipStrategyModel.js
+++ b/app/models/aipStrategyModel.js
@@ -41,6 +41,7 @@ const AipStartegySchema = new mongoose.Schema(
     profit_percentage: { type: Number, default: 0 }, // Profit percentage
     profit: { type: Number, default: 0 }, // Profit
     type: { type: Number, trim: true }, // Investment type. 1: Regular investment. 2: Intelligent investment
+    expect_growth_rate: { type: Number, default: 0.008 }, // Expected growth rate for value averaging (default 0.8%)
     status: {
       type: Number,
       default() {


### PR DESCRIPTION
## Summary
- **Fix 1 (C2):** Add `expect_growth_rate` field to strategy model with default `0.008` — prevents NaN in value averaging calculations
- **Fix 2 (C1):** Implement partial sell for intelligent strategies — previously sold ALL holdings instead of just the excess above expected value
- **Fix 3 (I2):** Rewrite `getSummary()` to use live prices from `DataExchangeSymbolModel` instead of stale `sell_price` (was always 0 for active strategies)
- **Fix 4 (I1):** Add `.select()` projection to `getPublicOrders()` — restricts public endpoint to only display-relevant fields

## Files Changed
- `app/models/aipStrategyModel.js` — Added `expect_growth_rate` field
- `app/models/aipAwaitModel.js` — Added `sell_amount` field for partial sell tracking
- `app/services/strategyService.js` — Updated `sellout()`, `processSell()`, `getSummary()`, `getPublicOrders()`
- `app/services/awaitService.js` — Updated `sellOnThirdParty()` for partial sell support
- `tests/unit/services/strategyService.test.js` — Added 6 new tests (intelligent sell, getSummary, getPublicOrders)
- `tests/unit/services/awaitService.test.js` — Added 2 new tests (partial sell amount, partial sell post-order)

## Test plan
- [x] `npm test -- --testPathPatterns=strategyService` — 32 tests pass
- [x] `npm test -- --testPathPatterns=awaitService` — 7 tests pass
- [x] `npm test` — 174 tests pass (1 flaky auth socket timeout on first run, passes on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)