### PR TITLE
feat: complete user management and add custom arbitrage query

### DIFF
--- a/app/controllers/arbitrageController.js
+++ b/app/controllers/arbitrageController.js
@@ -49,6 +49,14 @@ class ArbitrageController {
     const data = await ArbitrageService.refreshSymbols();
     return ResponseHandler.success(res, data);
   }
+
+  async getCustomOpportunities(req, res) {
+    const minProfit = parseFloat(req.query.minProfit) || 1;
+    const exchanges = req.query.exchanges ? req.query.exchanges.split(',') : [];
+    const symbols = req.query.symbols ? req.query.symbols.split(',') : [];
+    const data = await ArbitrageService.queryCustomOpportunities(minProfit, exchanges, symbols);
+    return ResponseHandler.success(res, data);
+  }
 }
 
 module.exports = new ArbitrageController();

--- a/app/controllers/userController.js
+++ b/app/controllers/userController.js
@@ -25,5 +25,24 @@ class UserController {
     const user = await UserService.updateUser(req.params.id, req.body);
     return ResponseHandler.success(res, user);
   }
+
+  async destroy(req, res) {
+    const result = await UserService.deleteUser(req.params.id, req.userId);
+    return ResponseHandler.success(res, result);
+  }
+
+  async profile(req, res) {
+    const user = await UserService.getProfile(req.userId);
+    return ResponseHandler.success(res, user);
+  }
+
+  async inviteList(req, res) {
+    const params = {
+      pageNumber: parseInt(req.query.pageNumber, 10) || 1,
+      pageSize: parseInt(req.query.pageSize, 10) || 20,
+    };
+    const data = await UserService.getInviteList(req.userId, params);
+    return ResponseHandler.success(res, data);
+  }
 }
 module.exports = new UserController();

--- a/app/routes/arbitrageRoutes.js
+++ b/app/routes/arbitrageRoutes.js
@@ -50,6 +50,36 @@ router.get('/api/v1/arbitrage/opportunities', ArbitrageController.getOpportuniti
 
 /**
  * @swagger
+ * /api/v1/arbitrage/opportunities/custom:
+ *   get:
+ *     summary: Get filtered arbitrage opportunities
+ *     tags:
+ *       - Arbitrage
+ *     parameters:
+ *       - in: query
+ *         name: minProfit
+ *         schema:
+ *           type: number
+ *           default: 1
+ *         description: Minimum profit percentage
+ *       - in: query
+ *         name: exchanges
+ *         schema:
+ *           type: string
+ *         description: Comma-separated exchange IDs (e.g. binance,bittrex)
+ *       - in: query
+ *         name: symbols
+ *         schema:
+ *           type: string
+ *         description: Comma-separated symbols (e.g. BTC/USDT,ETH/USDT)
+ *     responses:
+ *       200:
+ *         description: Filtered arbitrage opportunities
+ */
+router.get('/api/v1/arbitrage/opportunities/custom', ArbitrageController.getCustomOpportunities);
+
+/**
+ * @swagger
  * /api/v1/arbitrage/tickers/by-exchange:
  *   get:
  *     summary: Get tickers grouped by exchange
@@ -96,7 +126,7 @@ router.put(
   '/api/v1/arbitrage/config',
   authMiddleware,
   validateParams(saveConfigValidatorSchema),
-  ArbitrageController.saveConfig,
+  ArbitrageController.saveConfig
 );
 
 /**
@@ -133,6 +163,10 @@ router.get('/api/v1/arbitrage/symbols', authMiddleware, ArbitrageController.getA
  *     security:
  *       - tokenAuth: []
  */
-router.post('/api/v1/arbitrage/symbols/refresh', authMiddleware, ArbitrageController.refreshSymbols);
+router.post(
+  '/api/v1/arbitrage/symbols/refresh',
+  authMiddleware,
+  ArbitrageController.refreshSymbols
+);
 
 module.exports = router;

--- a/app/routes/userRoutes.js
+++ b/app/routes/userRoutes.js
@@ -39,6 +39,49 @@ router.get('/api/v1/users', authMiddleware, UserController.index);
 
 /**
  * @swagger
+ * /api/v1/users/profile:
+ *   get:
+ *     summary: Get current user's profile
+ *     tags:
+ *       - Users Management
+ *     description: Get the authenticated user's profile including referral code.
+ *     security:
+ *       - tokenAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile with ref_code
+ */
+router.get('/api/v1/users/profile', authMiddleware, UserController.profile);
+
+/**
+ * @swagger
+ * /api/v1/users/invitations:
+ *   get:
+ *     summary: Get list of invited users
+ *     tags:
+ *       - Users Management
+ *     description: Get paginated list of users invited by the current user.
+ *     security:
+ *       - tokenAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: pageNumber
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Paginated invitation list
+ */
+router.get('/api/v1/users/invitations', authMiddleware, UserController.inviteList);
+
+/**
+ * @swagger
  * /api/v1/users/{id}:
  *   get:
  *     summary: Get the specified user information
@@ -115,10 +158,12 @@ router.patch(
  * @swagger
  * /api/v1/users/{id}:
  *   delete:
- *     summary: Delete user (not enabled yet)
+ *     summary: Soft delete user account
  *     tags:
  *       - Users Management
- *     description: Delete a user by ID (not enabled in the current interface).
+ *     description: Soft delete a user account (sets is_deleted flag). Users can only delete their own account.
+ *     security:
+ *       - tokenAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -127,9 +172,9 @@ router.patch(
  *         required: true
  *         description: Unique ID of the user
  *     responses:
- *       501:
- *         description: This interface is not enabled yet
+ *       200:
+ *         description: User soft deleted successfully
  */
-// router.delete('/users/:id', UserController.deleteUser);
+router.delete('/api/v1/users/:id', authMiddleware, UserController.destroy);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- **User Management:** Added soft delete endpoint (`DELETE /api/v1/users/:id`), user profile with referral code (`GET /api/v1/users/profile`), and paginated invite list (`GET /api/v1/users/invitations`)
- **Arbitrage:** Added filtered arbitrage opportunities endpoint (`GET /api/v1/arbitrage/opportunities/custom`) supporting exchange and symbol filters
- **Tests:** Added 13 unit tests covering all new service methods (deleteUser, getProfile, getInviteList, queryCustomOpportunities)

## Files Changed (8)
| File | Changes |
|------|---------|
| `app/services/userService.js` | Added `deleteUser`, `getProfile`, `getInviteList` methods |
| `app/controllers/userController.js` | Added `destroy`, `profile`, `inviteList` handlers |
| `app/routes/userRoutes.js` | Added profile, invitations, delete routes (before `:id`) |
| `app/services/arbitrageService.js` | Added `queryCustomOpportunities` with `$in` filters |
| `app/controllers/arbitrageController.js` | Added `getCustomOpportunities` handler |
| `app/routes/arbitrageRoutes.js` | Added `/opportunities/custom` route |
| `tests/unit/services/userService.test.js` | 8 new tests for user service methods |
| `tests/unit/services/arbitrageService.test.js` | 5 new tests for custom arbitrage query |

## Test plan
- [x] All 187 tests pass (`npm test`)
- [x] Lint passes on modified files (pre-existing circular eslint/prettier issues excluded)
- [ ] Manual test: `GET /api/v1/users/profile` returns user with `ref_code`
- [ ] Manual test: `GET /api/v1/users/invitations` returns paginated invite list
- [ ] Manual test: `DELETE /api/v1/users/:id` soft deletes own account
- [ ] Manual test: `GET /api/v1/arbitrage/opportunities/custom?exchanges=binance,huobi` filters results

🤖 Generated with [Claude Code](https://claude.com/claude-code)