### PR TITLE
feat: add exchange rate and WeChat integration module

### DIFF
--- a/app/controllers/rateController.js
+++ b/app/controllers/rateController.js
@@ -1,0 +1,11 @@
+const RateService = require('../services/rateService');
+const ResponseHandler = require('../utils/responseHandler');
+
+class RateController {
+  async rmbRateList(req, res) {
+    const data = await RateService.getRmbRateList();
+    return ResponseHandler.success(res, data);
+  }
+}
+
+module.exports = new RateController();

--- a/app/controllers/wechatController.js
+++ b/app/controllers/wechatController.js
@@ -1,0 +1,36 @@
+const WechatService = require('../services/wechatService');
+const ResponseHandler = require('../utils/responseHandler');
+const config = require('../../config');
+
+class WechatController {
+  async checkToken(req, res) {
+    const result = WechatService.checkToken(req.query);
+    return res.send(result);
+  }
+
+  async getAccessToken(req, res) {
+    const data = await WechatService.getAccessToken();
+    return ResponseHandler.success(res, data);
+  }
+
+  async createMenu(req, res) {
+    const tokenData = await WechatService.getAccessToken();
+    if (!tokenData || !tokenData.access_token) {
+      return ResponseHandler.fail(res, 500, 1, 'Failed to get access token');
+    }
+    const menu = config.wechat?.menu || {};
+    const data = await WechatService.createMenu(tokenData.access_token, menu);
+    return ResponseHandler.success(res, data);
+  }
+
+  async deleteMenu(req, res) {
+    const tokenData = await WechatService.getAccessToken();
+    if (!tokenData || !tokenData.access_token) {
+      return ResponseHandler.fail(res, 500, 1, 'Failed to get access token');
+    }
+    const data = await WechatService.deleteMenu(tokenData.access_token);
+    return ResponseHandler.success(res, data);
+  }
+}
+
+module.exports = new WechatController();

--- a/app/models/clExchangeRatesModel.js
+++ b/app/models/clExchangeRatesModel.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const ClExchangeRatesSchema = new mongoose.Schema(
+  {
+    currency: { type: String, trim: true },
+    frate: { type: Number },
+  },
+  {
+    timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },
+    collection: 'cl_exchange_rates',
+  },
+);
+
+module.exports = mongoose.model('ClExchangeRates', ClExchangeRatesSchema);

--- a/app/routes/rateRoutes.js
+++ b/app/routes/rateRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const RateController = require('../controllers/rateController');
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /api/v1/rates:
+ *   get:
+ *     summary: Get exchange rate list (RMB-based)
+ *     tags: [Exchange Rates]
+ *     responses:
+ *       200:
+ *         description: Exchange rate list (virtual coins first, then legal tender)
+ */
+router.get('/api/v1/rates', RateController.rmbRateList);
+
+module.exports = router;

--- a/app/routes/wechatRoutes.js
+++ b/app/routes/wechatRoutes.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const WechatController = require('../controllers/wechatController');
+const authMiddleware = require('../middlewares/authMiddleware');
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /api/v1/wechat/check-token:
+ *   get:
+ *     summary: Validate WeChat server token
+ *     tags: [WeChat Integration]
+ *     parameters:
+ *       - in: query
+ *         name: signature
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: timestamp
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: nonce
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: echostr
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Returns echostr if valid
+ */
+router.get('/api/v1/wechat/check-token', WechatController.checkToken);
+
+/**
+ * @swagger
+ * /api/v1/wechat/access-token:
+ *   get:
+ *     summary: Get WeChat API access token
+ *     tags: [WeChat Integration]
+ *     security:
+ *       - tokenAuth: []
+ *     responses:
+ *       200:
+ *         description: Access token data
+ */
+router.get('/api/v1/wechat/access-token', authMiddleware, WechatController.getAccessToken);
+
+/**
+ * @swagger
+ * /api/v1/wechat/menu:
+ *   post:
+ *     summary: Create WeChat custom menu
+ *     tags: [WeChat Integration]
+ *     security:
+ *       - tokenAuth: []
+ *     responses:
+ *       200:
+ *         description: Menu creation result
+ */
+router.post('/api/v1/wechat/menu', authMiddleware, WechatController.createMenu);
+
+/**
+ * @swagger
+ * /api/v1/wechat/menu:
+ *   delete:
+ *     summary: Delete WeChat custom menu
+ *     tags: [WeChat Integration]
+ *     security:
+ *       - tokenAuth: []
+ *     responses:
+ *       200:
+ *         description: Menu deletion result
+ */
+router.delete('/api/v1/wechat/menu', authMiddleware, WechatController.deleteMenu);
+
+module.exports = router;

--- a/app/services/rateService.js
+++ b/app/services/rateService.js
@@ -1,0 +1,20 @@
+const ClExchangeRatesModel = require('../models/clExchangeRatesModel');
+
+class RateService {
+  async getRmbRateList() {
+    const legalCoins = ['cny', 'usd', 'eur', 'hkd', 'jpy', 'krw', 'aud', 'cad', 'rub'];
+    const virtualCoins = ['btc', 'eth', 'ltc', 'bch'];
+
+    const rates = await ClExchangeRatesModel.find({
+      $or: [{ currency: { $in: legalCoins } }, { currency: { $in: virtualCoins } }],
+    }).lean();
+
+    // Sort: virtual coins first, then legal tender
+    const virtual = rates.filter((r) => virtualCoins.includes(r.currency));
+    const legal = rates.filter((r) => legalCoins.includes(r.currency));
+
+    return { list: [...virtual, ...legal] };
+  }
+}
+
+module.exports = new RateService();

--- a/app/services/wechatService.js
+++ b/app/services/wechatService.js
@@ -1,0 +1,72 @@
+const crypto = require('crypto');
+const axios = require('axios');
+const CommonConfigService = require('./commonConfigService');
+const logger = require('../utils/logger');
+const config = require('../../config');
+
+class WechatService {
+  /**
+   * Validate WeChat server token
+   */
+  checkToken({ signature, timestamp, nonce, echostr }) {
+    const tokenStr = config.wechat?.tokenStr || '';
+    const arr = [tokenStr, timestamp, nonce].sort();
+    const hash = crypto.createHash('sha1').update(arr.join('')).digest('hex');
+    return hash === signature ? echostr : 'Invalid signature';
+  }
+
+  /**
+   * Get WeChat API access token (cached, refreshed every 2 hours)
+   */
+  async getAccessToken() {
+    const cached = await CommonConfigService.getAccessToken();
+    if (cached && cached.access_token) {
+      const age = Date.now() - new Date(cached.updated_at || 0).getTime();
+      if (age < 2 * 60 * 60 * 1000) {
+        return cached;
+      }
+    }
+    return this._refreshAccessToken();
+  }
+
+  async _refreshAccessToken() {
+    const appID = config.wechat?.appID;
+    const secret = config.wechat?.appSecret;
+    if (!appID || !secret) {
+      logger.error('[wechat] Missing appID or appSecret in config');
+      return null;
+    }
+
+    const url = `https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${appID}&secret=${secret}`;
+    const res = await axios.get(url);
+
+    if (res.data && res.data.access_token) {
+      const tokenData = { access_token: res.data.access_token, updated_at: new Date() };
+      await CommonConfigService.setAccessToken(tokenData);
+      return tokenData;
+    }
+
+    logger.error(`[wechat] Failed to refresh access token: ${JSON.stringify(res.data)}`);
+    return null;
+  }
+
+  /**
+   * Create WeChat custom menu
+   */
+  async createMenu(accessToken, menu) {
+    const url = `https://api.weixin.qq.com/cgi-bin/menu/create?access_token=${accessToken}`;
+    const res = await axios.post(url, menu);
+    return res.data;
+  }
+
+  /**
+   * Delete WeChat custom menu
+   */
+  async deleteMenu(accessToken) {
+    const url = `https://api.weixin.qq.com/cgi-bin/menu/delete?access_token=${accessToken}`;
+    const res = await axios.get(url);
+    return res.data;
+  }
+}
+
+module.exports = new WechatService();

--- a/config/index.js
+++ b/config/index.js
@@ -50,9 +50,17 @@ const config = {
   },
 
   // Currency exchange from USD to others
-  currencyRate:{
+  currencyRate: {
     apiUrl: 'https://api.exchangerate-api.com/v4/latest/USD',
-  }
+  },
+
+  // WeChat integration
+  wechat: {
+    tokenStr: process.env.WECHAT_TOKEN || '',
+    appID: process.env.WECHAT_APP_ID || '',
+    appSecret: process.env.WECHAT_APP_SECRET || '',
+    menu: {},
+  },
 };
 
 module.exports = config;

--- a/tests/unit/services/rateService.test.js
+++ b/tests/unit/services/rateService.test.js
@@ -1,0 +1,64 @@
+jest.mock('../../../app/models/clExchangeRatesModel');
+
+const ClExchangeRatesModel = require('../../../app/models/clExchangeRatesModel');
+const RateService = require('../../../app/services/rateService');
+
+describe('RateService', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('getRmbRateList()', () => {
+    it('should return virtual coins before legal tender', async () => {
+      const mockRates = [
+        { currency: 'cny', frate: 7.2 },
+        { currency: 'usd', frate: 1 },
+        { currency: 'btc', frate: 50000 },
+        { currency: 'eth', frate: 3000 },
+        { currency: 'eur', frate: 0.92 },
+      ];
+
+      ClExchangeRatesModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockRates),
+      });
+
+      const result = await RateService.getRmbRateList();
+
+      expect(result.list).toHaveLength(5);
+      // Virtual coins should come first
+      expect(result.list[0].currency).toBe('btc');
+      expect(result.list[1].currency).toBe('eth');
+      // Legal tender after
+      expect(result.list[2].currency).toBe('cny');
+      expect(result.list[3].currency).toBe('usd');
+      expect(result.list[4].currency).toBe('eur');
+    });
+
+    it('should return empty list when no data', async () => {
+      ClExchangeRatesModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await RateService.getRmbRateList();
+
+      expect(result.list).toHaveLength(0);
+      expect(result.list).toEqual([]);
+    });
+
+    it('should query with correct currency filters', async () => {
+      ClExchangeRatesModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await RateService.getRmbRateList();
+
+      expect(ClExchangeRatesModel.find).toHaveBeenCalledWith({
+        $or: [
+          { currency: { $in: ['cny', 'usd', 'eur', 'hkd', 'jpy', 'krw', 'aud', 'cad', 'rub'] } },
+          { currency: { $in: ['btc', 'eth', 'ltc', 'bch'] } },
+        ],
+      });
+    });
+  });
+});

--- a/tests/unit/services/wechatService.test.js
+++ b/tests/unit/services/wechatService.test.js
@@ -1,0 +1,156 @@
+jest.mock('axios');
+jest.mock('../../../app/services/commonConfigService');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const crypto = require('crypto');
+const axios = require('axios');
+const CommonConfigService = require('../../../app/services/commonConfigService');
+const config = require('../../../config');
+const WechatService = require('../../../app/services/wechatService');
+
+// Store original config and restore after tests
+const originalWechat = { ...config.wechat };
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+
+  // Reset config for each test
+  config.wechat = {
+    tokenStr: 'test-token',
+    appID: 'test-app-id',
+    appSecret: 'test-app-secret',
+    menu: { button: [] },
+  };
+});
+
+afterAll(() => {
+  config.wechat = originalWechat;
+});
+
+describe('WechatService', () => {
+  describe('checkToken()', () => {
+    it('should return echostr for valid signature', () => {
+      const timestamp = '1234567890';
+      const nonce = 'test-nonce';
+      const echostr = 'echo-string';
+      const tokenStr = 'test-token';
+
+      // Compute the expected signature
+      const arr = [tokenStr, timestamp, nonce].sort();
+      const expectedHash = crypto.createHash('sha1').update(arr.join('')).digest('hex');
+
+      const result = WechatService.checkToken({
+        signature: expectedHash,
+        timestamp,
+        nonce,
+        echostr,
+      });
+
+      expect(result).toBe(echostr);
+    });
+
+    it('should return error string for invalid signature', () => {
+      const result = WechatService.checkToken({
+        signature: 'invalid-signature',
+        timestamp: '1234567890',
+        nonce: 'test-nonce',
+        echostr: 'echo-string',
+      });
+
+      expect(result).toBe('Invalid signature');
+    });
+  });
+
+  describe('getAccessToken()', () => {
+    it('should return cached token if fresh (< 2 hours)', async () => {
+      const cachedToken = {
+        access_token: 'cached-token-123',
+        updated_at: new Date(), // just now
+      };
+      CommonConfigService.getAccessToken.mockResolvedValue(cachedToken);
+
+      const result = await WechatService.getAccessToken();
+
+      expect(result).toEqual(cachedToken);
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('should refresh token if stale (> 2 hours)', async () => {
+      const staleToken = {
+        access_token: 'old-token',
+        updated_at: new Date(Date.now() - 3 * 60 * 60 * 1000), // 3 hours ago
+      };
+      CommonConfigService.getAccessToken.mockResolvedValue(staleToken);
+      CommonConfigService.setAccessToken.mockResolvedValue(null);
+
+      axios.get.mockResolvedValue({
+        data: { access_token: 'new-token-456' },
+      });
+
+      const result = await WechatService.getAccessToken();
+
+      expect(result.access_token).toBe('new-token-456');
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('api.weixin.qq.com/cgi-bin/token')
+      );
+      expect(CommonConfigService.setAccessToken).toHaveBeenCalled();
+    });
+
+    it('should refresh token if no cached token exists', async () => {
+      CommonConfigService.getAccessToken.mockResolvedValue(null);
+      CommonConfigService.setAccessToken.mockResolvedValue(null);
+
+      axios.get.mockResolvedValue({
+        data: { access_token: 'fresh-token' },
+      });
+
+      const result = await WechatService.getAccessToken();
+
+      expect(result.access_token).toBe('fresh-token');
+    });
+
+    it('should return null if config is missing appID/appSecret', async () => {
+      config.wechat = { tokenStr: 'test', appID: '', appSecret: '' };
+      CommonConfigService.getAccessToken.mockResolvedValue(null);
+
+      const result = await WechatService.getAccessToken();
+
+      expect(result).toBeNull();
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createMenu()', () => {
+    it('should call WeChat API with correct URL and menu data', async () => {
+      const menu = { button: [{ type: 'click', name: 'Test' }] };
+      axios.post.mockResolvedValue({ data: { errcode: 0, errmsg: 'ok' } });
+
+      const result = await WechatService.createMenu('test-access-token', menu);
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://api.weixin.qq.com/cgi-bin/menu/create?access_token=test-access-token',
+        menu
+      );
+      expect(result).toEqual({ errcode: 0, errmsg: 'ok' });
+    });
+  });
+
+  describe('deleteMenu()', () => {
+    it('should call WeChat API with correct URL', async () => {
+      axios.get.mockResolvedValue({ data: { errcode: 0, errmsg: 'ok' } });
+
+      const result = await WechatService.deleteMenu('test-access-token');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://api.weixin.qq.com/cgi-bin/menu/delete?access_token=test-access-token'
+      );
+      expect(result).toEqual({ errcode: 0, errmsg: 'ok' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ClExchangeRates` model for pre-computed currency rates (`cl_exchange_rates` collection)
- Add Rate module (service/controller/route) with public `GET /api/v1/rates` endpoint returning virtual coins before legal tender
- Add WeChat module (service/controller/routes) with token validation, access token caching (2h TTL), and menu CRUD via WeChat API
- Add WeChat config section to `config/index.js` with env-var-driven `WECHAT_TOKEN`, `WECHAT_APP_ID`, `WECHAT_APP_SECRET`
- Add 11 unit tests covering rate list ordering and WeChat token validation, access token refresh, and menu API calls

## New Files
| File | Purpose |
|------|---------|
| `app/models/clExchangeRatesModel.js` | Exchange rate model (currency + frate) |
| `app/services/rateService.js` | Rate list query with virtual/legal coin ordering |
| `app/controllers/rateController.js` | Rate HTTP handler |
| `app/routes/rateRoutes.js` | `GET /api/v1/rates` (public) |
| `app/services/wechatService.js` | WeChat token validation, access token cache, menu CRUD |
| `app/controllers/wechatController.js` | WeChat HTTP handlers |
| `app/routes/wechatRoutes.js` | 4 WeChat endpoints (check-token, access-token, menu) |
| `tests/unit/services/rateService.test.js` | 3 rate service tests |
| `tests/unit/services/wechatService.test.js` | 8 wechat service tests |

## New Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/v1/rates` | No | Exchange rate list (virtual coins first) |
| GET | `/api/v1/wechat/check-token` | No | WeChat server token validation |
| GET | `/api/v1/wechat/access-token` | Yes | Get cached WeChat API access token |
| POST | `/api/v1/wechat/menu` | Yes | Create WeChat custom menu |
| DELETE | `/api/v1/wechat/menu` | Yes | Delete WeChat custom menu |

## Test plan
- [x] All 198 tests pass (18 suites, 0 failures)
- [x] 11 new unit tests for rate and wechat services
- [x] No regressions in existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)