### PR TITLE
feat: add BTC history API and cron for homepage

### DIFF
--- a/app/controllers/homeController.js
+++ b/app/controllers/homeController.js
@@ -1,4 +1,6 @@
 const { hashidsEncode, hashidsDecode } = require('../utils/hashidsHandler');
+const HomeService = require('../services/homeService');
+const ResponseHandler = require('../utils/responseHandler');
 
 class HomeController {
   async index(req, res) {
@@ -15,6 +17,25 @@ class HomeController {
   async checkTask(req, res) {
     // const taskStatus = task.getStatus(); // Returns the status of the scheduled task
     res.json({ status: true });
+  }
+
+  /**
+   * GET /api/v1/public/btc-history
+   * Returns BTC price history for the homepage chart.
+   */
+  async getBtcHistory(req, res) {
+    const params = req.query;
+    const data = await HomeService.getBtcHistory(params);
+    return ResponseHandler.success(res, data);
+  }
+
+  /**
+   * GET /api/v1/public/dingtou/orders
+   * Returns the public DCA demo order list.
+   */
+  async getDingtouOrders(req, res) {
+    const data = await HomeService.getDingtouOrders();
+    return ResponseHandler.success(res, data);
   }
 }
 module.exports = new HomeController();

--- a/app/models/dataBtcHistoryModel.js
+++ b/app/models/dataBtcHistoryModel.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const DataBtcHistorySchema = new Schema(
+  {
+    date: { type: String, required: true, unique: true }, // Date string YYYY-MM-DD
+    open: { type: Number },
+    high: { type: Number },
+    low: { type: Number },
+    close: { type: Number },
+    volume: { type: Number },
+    exchange: { type: String, default: 'binance' },
+    symbol: { type: String, default: 'BTC/USDT' },
+  },
+  {
+    timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },
+    collection: 'data_btc_history',
+  }
+);
+
+DataBtcHistorySchema.index({ date: -1 });
+
+module.exports = mongoose.model('DataBtcHistory', DataBtcHistorySchema);

--- a/app/routes/homeRoutes.js
+++ b/app/routes/homeRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const HomeController = require('../controllers/homeController');
+
 const router = express.Router();
 
 /**
@@ -67,5 +68,84 @@ router.get('/test', HomeController.test);
  *                   example: true
  */
 router.get('/check-task', HomeController.checkTask);
+
+/**
+ * @swagger
+ * /api/v1/public/btc-history:
+ *   get:
+ *     summary: Get BTC price history
+ *     tags:
+ *       - Home
+ *     description: Returns BTC/USDT daily price history for the homepage chart. No authentication required.
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 365
+ *         description: Maximum number of data points to return
+ *     responses:
+ *       200:
+ *         description: Successfully returned BTC price history
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 0
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     list:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           date:
+ *                             type: string
+ *                             example: "2025-01-15"
+ *                           open:
+ *                             type: number
+ *                           high:
+ *                             type: number
+ *                           low:
+ *                             type: number
+ *                           close:
+ *                             type: number
+ *                           volume:
+ *                             type: number
+ */
+router.get('/api/v1/public/btc-history', HomeController.getBtcHistory);
+
+/**
+ * @swagger
+ * /api/v1/public/dingtou/orders:
+ *   get:
+ *     summary: Get public DCA demo orders
+ *     tags:
+ *       - Home
+ *     description: Returns the order history for the showcase DCA strategy. No authentication required.
+ *     responses:
+ *       200:
+ *         description: Successfully returned DCA demo orders
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 0
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     list:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ */
+router.get('/api/v1/public/dingtou/orders', HomeController.getDingtouOrders);
 
 module.exports = router;

--- a/app/schedulers/btcHistoryScheduler.js
+++ b/app/schedulers/btcHistoryScheduler.js
@@ -1,0 +1,26 @@
+const cron = require('node-cron');
+const HomeService = require('../services/homeService');
+const logger = require('../utils/logger');
+
+let isRunning = false;
+
+const btcHistoryScheduler = () => {
+  // Run daily at 00:05 UTC to capture the previous day's close
+  cron.schedule('5 0 * * *', async () => {
+    if (isRunning) {
+      logger.info('btcHistoryScheduler: previous execution still running, skipping');
+      return;
+    }
+    isRunning = true;
+    try {
+      logger.info(`btcHistoryScheduler: running at ${new Date().toISOString()}`);
+      await HomeService.fetchAndStoreBtcPrice();
+    } catch (error) {
+      logger.error(`btcHistoryScheduler: error - ${error.message}`);
+    } finally {
+      isRunning = false;
+    }
+  });
+};
+
+module.exports = btcHistoryScheduler;

--- a/app/services/homeService.js
+++ b/app/services/homeService.js
@@ -1,0 +1,88 @@
+const ccxt = require('ccxt');
+const dayjs = require('dayjs');
+const DataBtcHistoryModel = require('../models/dataBtcHistoryModel');
+const CommonConfigModel = require('../models/commonConfigModel');
+const AipOrderModel = require('../models/aipOrderModel');
+const logger = require('../utils/logger');
+
+class HomeService {
+  /**
+   * Get BTC price history for homepage chart.
+   * Returns up to `limit` recent daily data points sorted by date ascending.
+   * @param {object} params
+   * @param {number} [params.limit=365] - Max data points to return
+   * @returns {Promise<{list: Array}>}
+   */
+  async getBtcHistory(params = {}) {
+    const limit = params.limit || 365;
+
+    const list = await DataBtcHistoryModel.find({}).sort({ date: -1 }).limit(limit).lean();
+
+    // Return in chronological order (oldest first) for chart rendering
+    list.reverse();
+
+    return { list };
+  }
+
+  /**
+   * Get public DCA demo order list (the showcase strategy orders).
+   * Reads the configured dingtou_id from common_configs and returns its orders.
+   * @returns {Promise<{list: Array}>}
+   */
+  async getDingtouOrders() {
+    const config = await CommonConfigModel.findOne({ name: 'dingtou_id' }).lean();
+    const dingtouId = config ? config.content : null;
+
+    if (!dingtouId) {
+      return { list: [] };
+    }
+
+    const list = await AipOrderModel.find({ strategy_id: dingtouId })
+      .sort({ created_at: 1 })
+      .lean();
+
+    return { list };
+  }
+
+  /**
+   * Fetch the latest BTC/USDT daily OHLCV from Binance via CCXT and upsert into DB.
+   * Called by the btcHistoryScheduler cron job.
+   * @returns {Promise<number>} Number of records upserted
+   */
+  async fetchAndStoreBtcPrice() {
+    // eslint-disable-next-line new-cap
+    const exchange = new ccxt.binance({ enableRateLimit: true });
+
+    // Fetch last 2 days of daily candles to ensure we capture today's closing
+    const since = dayjs().subtract(2, 'day').startOf('day').valueOf();
+    const ohlcv = await exchange.fetchOHLCV('BTC/USDT', '1d', since, 2);
+
+    if (!ohlcv || ohlcv.length === 0) {
+      logger.warn('btcHistoryScheduler: No OHLCV data returned from exchange');
+      return 0;
+    }
+
+    const bulkOps = ohlcv.map((candle) => {
+      const [timestamp, open, high, low, close, volume] = candle;
+      const date = dayjs(timestamp).format('YYYY-MM-DD');
+
+      return {
+        updateOne: {
+          filter: { date },
+          update: {
+            $set: { open, high, low, close, volume, exchange: 'binance', symbol: 'BTC/USDT' },
+          },
+          upsert: true,
+        },
+      };
+    });
+
+    const result = await DataBtcHistoryModel.bulkWrite(bulkOps);
+    const upsertedCount = result.upsertedCount + result.modifiedCount;
+
+    logger.info(`btcHistoryScheduler: upserted ${upsertedCount} BTC history records`);
+    return upsertedCount;
+  }
+}
+
+module.exports = new HomeService();

--- a/tests/unit/services/homeService.test.js
+++ b/tests/unit/services/homeService.test.js
@@ -1,0 +1,182 @@
+jest.mock('../../../app/models/dataBtcHistoryModel');
+jest.mock('../../../app/models/commonConfigModel');
+jest.mock('../../../app/models/aipOrderModel');
+jest.mock('ccxt');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const DataBtcHistoryModel = require('../../../app/models/dataBtcHistoryModel');
+const CommonConfigModel = require('../../../app/models/commonConfigModel');
+const AipOrderModel = require('../../../app/models/aipOrderModel');
+const ccxt = require('ccxt');
+const HomeService = require('../../../app/services/homeService');
+
+describe('HomeService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getBtcHistory()', () => {
+    it('should return BTC history list in chronological order', async () => {
+      const mockData = [
+        { date: '2025-01-02', close: 98000 },
+        { date: '2025-01-01', close: 97000 },
+      ];
+
+      DataBtcHistoryModel.find.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue([...mockData]),
+          }),
+        }),
+      });
+
+      const result = await HomeService.getBtcHistory({ limit: 30 });
+
+      expect(DataBtcHistoryModel.find).toHaveBeenCalledWith({});
+      expect(result.list).toHaveLength(2);
+      // Should be reversed to chronological order
+      expect(result.list[0].date).toBe('2025-01-01');
+      expect(result.list[1].date).toBe('2025-01-02');
+    });
+
+    it('should use default limit of 365 when not provided', async () => {
+      DataBtcHistoryModel.find.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      await HomeService.getBtcHistory();
+
+      const sortMock = DataBtcHistoryModel.find().sort;
+      expect(sortMock).toHaveBeenCalledWith({ date: -1 });
+      const limitMock = sortMock().limit;
+      expect(limitMock).toHaveBeenCalledWith(365);
+    });
+
+    it('should return empty list when no data exists', async () => {
+      DataBtcHistoryModel.find.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await HomeService.getBtcHistory();
+
+      expect(result.list).toHaveLength(0);
+    });
+  });
+
+  describe('getDingtouOrders()', () => {
+    it('should return orders for configured dingtou_id', async () => {
+      CommonConfigModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ name: 'dingtou_id', content: 'strat-123' }),
+      });
+
+      const mockOrders = [
+        { _id: 'order-1', strategy_id: 'strat-123', side: 'buy' },
+        { _id: 'order-2', strategy_id: 'strat-123', side: 'buy' },
+      ];
+
+      AipOrderModel.find.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue(mockOrders),
+        }),
+      });
+
+      const result = await HomeService.getDingtouOrders();
+
+      expect(CommonConfigModel.findOne).toHaveBeenCalledWith({ name: 'dingtou_id' });
+      expect(AipOrderModel.find).toHaveBeenCalledWith({ strategy_id: 'strat-123' });
+      expect(result.list).toHaveLength(2);
+    });
+
+    it('should return empty list when dingtou_id config not found', async () => {
+      CommonConfigModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await HomeService.getDingtouOrders();
+
+      expect(result.list).toHaveLength(0);
+    });
+
+    it('should return empty list when dingtou_id content is falsy', async () => {
+      CommonConfigModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ name: 'dingtou_id', content: null }),
+      });
+
+      const result = await HomeService.getDingtouOrders();
+
+      expect(result.list).toHaveLength(0);
+    });
+  });
+
+  describe('fetchAndStoreBtcPrice()', () => {
+    it('should fetch OHLCV data and bulkWrite to DB', async () => {
+      const mockOhlcv = [
+        [1705276800000, 96000, 98000, 95000, 97000, 12345.67],
+        [1705363200000, 97000, 99000, 96500, 98500, 11234.56],
+      ];
+
+      const mockExchange = {
+        fetchOHLCV: jest.fn().mockResolvedValue(mockOhlcv),
+      };
+
+      ccxt.binance = jest.fn().mockImplementation(() => mockExchange);
+
+      DataBtcHistoryModel.bulkWrite = jest.fn().mockResolvedValue({
+        upsertedCount: 2,
+        modifiedCount: 0,
+      });
+
+      const result = await HomeService.fetchAndStoreBtcPrice();
+
+      expect(mockExchange.fetchOHLCV).toHaveBeenCalledWith('BTC/USDT', '1d', expect.any(Number), 2);
+      expect(DataBtcHistoryModel.bulkWrite).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            updateOne: expect.objectContaining({
+              filter: expect.objectContaining({ date: expect.any(String) }),
+              upsert: true,
+            }),
+          }),
+        ])
+      );
+      expect(result).toBe(2);
+    });
+
+    it('should return 0 when exchange returns no data', async () => {
+      const mockExchange = {
+        fetchOHLCV: jest.fn().mockResolvedValue([]),
+      };
+
+      ccxt.binance = jest.fn().mockImplementation(() => mockExchange);
+
+      const result = await HomeService.fetchAndStoreBtcPrice();
+
+      expect(result).toBe(0);
+      expect(DataBtcHistoryModel.bulkWrite).not.toHaveBeenCalled();
+    });
+
+    it('should return 0 when exchange returns null', async () => {
+      const mockExchange = {
+        fetchOHLCV: jest.fn().mockResolvedValue(null),
+      };
+
+      ccxt.binance = jest.fn().mockImplementation(() => mockExchange);
+
+      const result = await HomeService.fetchAndStoreBtcPrice();
+
+      expect(result).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `DataBtcHistory` model for storing daily BTC/USDT OHLCV data
- Add `homeService.js` with `getBtcHistory()`, `getDingtouOrders()`, and `fetchAndStoreBtcPrice()` methods
- Add public API endpoints `GET /api/v1/public/btc-history` and `GET /api/v1/public/dingtou/orders` (no auth required)
- Add `btcHistoryScheduler.js` cron job (daily at 00:05 UTC) to fetch BTC price via CCXT and store to DB
- Add 9 unit tests for homeService covering all methods

## Test plan
- [x] All 9 new unit tests pass (getBtcHistory, getDingtouOrders, fetchAndStoreBtcPrice)
- [x] All 253 existing tests still pass (23 suites)
- [x] Lint passes for new files (only pre-existing ccxt import/no-unresolved and config-level comma-dangle/prettier conflict remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)