### PR TITLE
feat: add change password API and RBAC permission checking

### DIFF
--- a/app/controllers/authController.js
+++ b/app/controllers/authController.js
@@ -99,6 +99,25 @@ class AuthController {
     return ResponseHandler.success(res, data);
   }
 
+  async sendCode(req, res) {
+    const { userId } = req;
+    const data = await AuthService.sendVerificationCode(userId);
+    return ResponseHandler.success(res, data);
+  }
+
+  async changePassword(req, res) {
+    const { userId } = req;
+    const { code, newPassword } = req.body;
+    const data = await AuthService.changePassword(userId, code, newPassword);
+    return ResponseHandler.success(res, data);
+  }
+
+  async permissions(req, res) {
+    const { userId } = req;
+    const data = await AuthService.getUserPermission(userId);
+    return ResponseHandler.success(res, data);
+  }
+
   // send retrieve password email
   async sendRetrieveEmail(req, res) {
     const { userEmail, captcha } = req.body;

--- a/app/middlewares/rbacMiddleware.js
+++ b/app/middlewares/rbacMiddleware.js
@@ -1,0 +1,30 @@
+const AuthService = require('../services/authService');
+const CustomError = require('../utils/customError');
+const { STATUS_TYPE } = require('../utils/statusCodes');
+
+const requirePermission = (resourceCode) => async (req, _res, next) => {
+  const { userId } = req;
+  if (!userId) {
+    throw new CustomError(STATUS_TYPE.HTTP_UNAUTHORIZED, 401, 'Authentication required');
+  }
+
+  const permission = await AuthService.getUserPermission(userId);
+
+  if (!permission.role) {
+    throw new CustomError(STATUS_TYPE.COMMON_ACCESS_FORBIDDEN, 403, 'Access forbidden');
+  }
+
+  // Admin role bypasses all permission checks
+  if (permission.role.role_name === 'admin') {
+    return next();
+  }
+
+  const hasPermission = permission.resources.some((r) => r.resource_code === resourceCode);
+  if (!hasPermission) {
+    throw new CustomError(STATUS_TYPE.COMMON_ACCESS_FORBIDDEN, 403, 'Access forbidden');
+  }
+
+  return next();
+};
+
+module.exports = { requirePermission };

--- a/app/models/portalUserModel.js
+++ b/app/models/portalUserModel.js
@@ -12,7 +12,7 @@ const PortalUserSchema = new mongoose.Schema(
     mobile: { type: String, default: '', trim: true }, // phone number
     instagram: { type: String, default: '', trim: true }, // instagram account
     invitation_code: { type: String, trim: true }, // user's own referral code
-    // role: { type: Schema.Types.ObjectId, ref: 'PortalRole', default: [] }, // role resource
+    role: { type: mongoose.Schema.Types.ObjectId, ref: 'portal_role', default: null },
     last_login_time: { type: Date }, // lastest login time
     vip_time_out_at: { type: Date }, // VIP expire time
     last_login_IP: { type: String, trim: true }, // lastest login IP

--- a/app/routes/authRoutes.js
+++ b/app/routes/authRoutes.js
@@ -6,6 +6,7 @@ const {
   sendActivateEmailValidatorSchema,
   createUserValidatorSchema,
   retrievePasswordValidatorSchema,
+  changePasswordValidatorSchema,
 } = require('../validators/authValidator');
 const authMiddleware = require('../middlewares/authMiddleware');
 const AuthController = require('../controllers/authController');
@@ -230,5 +231,71 @@ router.post(
   validateParams(retrievePasswordValidatorSchema),
   AuthController.sendRetrieveEmail
 );
+
+/**
+ * @swagger
+ * /api/v1/auth/send-code:
+ *   post:
+ *     summary: Send verification code for password change
+ *     tags:
+ *       - Authentication
+ *     description: Sends a 6-digit verification code to the authenticated user's email.
+ *     security:
+ *       - tokenAuth: []
+ *     responses:
+ *       200:
+ *         description: Verification code sent
+ */
+router.post('/api/v1/auth/send-code', authMiddleware, AuthController.sendCode);
+
+/**
+ * @swagger
+ * /api/v1/auth/change-password:
+ *   post:
+ *     summary: Change password with verification code
+ *     tags:
+ *       - Authentication
+ *     description: Change the authenticated user's password using the verification code.
+ *     security:
+ *       - tokenAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                 type: string
+ *                 example: '123456'
+ *               newPassword:
+ *                 type: string
+ *                 example: 'newpassword123'
+ *     responses:
+ *       200:
+ *         description: Password changed successfully
+ */
+router.post(
+  '/api/v1/auth/change-password',
+  authMiddleware,
+  validateParams(changePasswordValidatorSchema),
+  AuthController.changePassword,
+);
+
+/**
+ * @swagger
+ * /api/v1/auth/permissions:
+ *   get:
+ *     summary: Get current user permissions
+ *     tags:
+ *       - Authentication
+ *     description: Returns the current user's role and resource permissions.
+ *     security:
+ *       - tokenAuth: []
+ *     responses:
+ *       200:
+ *         description: User permissions retrieved successfully
+ */
+router.get('/api/v1/auth/permissions', authMiddleware, AuthController.permissions);
 
 module.exports = router;

--- a/app/services/authService.js
+++ b/app/services/authService.js
@@ -17,6 +17,7 @@ const { hashidsEncode, hashidsDecode } = require('../utils/hashidsHandler');
 const logger = require('../utils/logger');
 const CommonConfigService = require('./commonConfigService');
 const AssetsService = require('./assetsService');
+const PortalRoleModel = require('../models/portalRoleModel');
 
 class AuthService {
   // verify captcha
@@ -370,6 +371,115 @@ class AuthService {
     await PortalTokenModel.deleteOne({ _id: existToken._id });
     return {
       message: 'Account activation successful.',
+    };
+  }
+
+  async sendVerificationCode(userId) {
+    const user = await PortalUserModel.findById(userId).lean();
+    if (!user) {
+      throw new CustomError(STATUS_TYPE.PORTAL_USER_NOT_FOUND);
+    }
+
+    // Rate limit: check whether already sent code in 5 mins
+    const existToken = await PortalTokenModel.findOne({
+      user_id: user._id,
+      type: 'change_password',
+    });
+    if (existToken) {
+      if ((+new Date() - existToken.last_access_time) / 1000 < config.minEmailSendInterval) {
+        throw new CustomError(STATUS_TYPE.PORTAL_EMAIL_SEND_LIMIT);
+      } else {
+        await PortalTokenModel.deleteOne({ _id: existToken._id });
+      }
+    }
+
+    // Generate 6-digit code
+    const code = String(Math.floor(100000 + Math.random() * 900000));
+    await new PortalTokenModel({
+      user_id: user._id,
+      token: code,
+      email: user.email,
+      nick_name: user.nick_name,
+      type: 'change_password',
+      last_access_time: +new Date(),
+    }).save();
+
+    const { siteName } = config;
+    const { siteUrl } = config;
+    const displayName = user.nick_name;
+    const codMailPath = path.resolve(__dirname, '../views/verification_code_mail.html');
+
+    const html = await ejs.renderFile(codMailPath, {
+      siteName,
+      displayName,
+      code,
+      siteUrl,
+    });
+    const codeEmail = {
+      async: false,
+      to: [user.email],
+      subject: `[${siteName}] Verification Code`,
+      text: `Hello ${displayName}, your verification code is: ${code}. It expires in 5 minutes.`,
+      html,
+    };
+
+    const sendEmailRes = await EmailService.sendEmail(codeEmail);
+    if (sendEmailRes.emailStatus === PortalEmailInfoModel.STATUS_FAILED) {
+      logger.error('Error sending verification code email:', sendEmailRes.desc);
+    }
+
+    return { message: 'Verification code email will be sent!' };
+  }
+
+  async changePassword(userId, code, newPassword) {
+    const tokenDoc = await PortalTokenModel.findOne({
+      user_id: userId,
+      token: code,
+      type: 'change_password',
+    });
+
+    if (!tokenDoc) {
+      throw new CustomError(STATUS_TYPE.PORTAL_VERIFICATION_CODE_INVALID);
+    }
+
+    if ((+new Date() - tokenDoc.last_access_time) / 1000 > config.tokenTimeOut) {
+      await PortalTokenModel.deleteOne({ _id: tokenDoc._id });
+      throw new CustomError(STATUS_TYPE.PORTAL_VERIFICATION_CODE_EXPIRED);
+    }
+
+    const user = await PortalUserModel.findById(userId);
+    if (!user) {
+      throw new CustomError(STATUS_TYPE.PORTAL_USER_NOT_FOUND);
+    }
+
+    const pwd = await UserService.generatePassword(newPassword);
+    user.password = pwd.password;
+    user.salt = pwd.salt;
+    await user.save();
+
+    await PortalTokenModel.deleteOne({ _id: tokenDoc._id });
+
+    return { message: 'Password changed successfully' };
+  }
+
+  async getUserPermission(userId) {
+    const user = await PortalUserModel.findById(userId).populate('role').lean();
+    if (!user || !user.role) {
+      return { role: null, resources: [] };
+    }
+
+    const role = await PortalRoleModel.findById(user.role._id).populate('resource').lean();
+    if (!role) {
+      return { role: null, resources: [] };
+    }
+
+    return {
+      role: {
+        _id: role._id,
+        role_name: role.role_name,
+        role_description: role.role_description,
+      },
+      resources: role.resource || [],
     };
   }
 

--- a/app/utils/statusCodes.js
+++ b/app/utils/statusCodes.js
@@ -61,6 +61,8 @@ const STATUS_TYPE = {
   PORTAL_USER_ALREADY_ACTIVATED: 11014, // This user account is already activated
   PORTAL_EMAIL_SEND_LIMIT: 11015, // Email cannot be sent more than once within 5 minutes.
   PORTAL_CAPTCHA_INVAILD: 11016, // Captcha is invaild.
+  PORTAL_VERIFICATION_CODE_INVALID: 11017, // Verification code is invalid
+  PORTAL_VERIFICATION_CODE_EXPIRED: 11018, // Verification code has expired
 
   // Custom status codes for aip module (12001-13000)
   AIP_SERVER_BUSY: 12001, // Trading module server is busy
@@ -138,6 +140,8 @@ const STATUS_MESSAGE_ZH = {
   [STATUS_TYPE.PORTAL_USER_ALREADY_ACTIVATED]: '该注册账号已经处于激活状态',
   [STATUS_TYPE.PORTAL_EMAIL_SEND_LIMIT]: '邮箱请求在5分钟内不能超过一次',
   [STATUS_TYPE.PORTAL_CAPTCHA_INVAILD]: '验证码错误',
+  [STATUS_TYPE.PORTAL_VERIFICATION_CODE_INVALID]: '验证码无效',
+  [STATUS_TYPE.PORTAL_VERIFICATION_CODE_EXPIRED]: '验证码已过期',
 
   // AIP module messages
   [STATUS_TYPE.AIP_SERVER_BUSY]: '交易模块服务器繁忙',
@@ -216,6 +220,8 @@ const STATUS_MESSAGE = {
   [STATUS_TYPE.PORTAL_EMAIL_SEND_LIMIT]:
     'Multiple email sends within a short period are not allowed. Please wait 5 minutes to resend',
   [STATUS_TYPE.PORTAL_CAPTCHA_INVAILD]: 'Captcha is invaild',
+  [STATUS_TYPE.PORTAL_VERIFICATION_CODE_INVALID]: 'Verification code is invalid',
+  [STATUS_TYPE.PORTAL_VERIFICATION_CODE_EXPIRED]: 'Verification code has expired',
 
   // AIP module messages
   [STATUS_TYPE.AIP_SERVER_BUSY]: 'Trading module server is busy',

--- a/app/validators/authValidator.js
+++ b/app/validators/authValidator.js
@@ -44,10 +44,29 @@ const createUserValidatorSchema = {
   },
 };
 
+const changePasswordValidatorSchema = {
+  code: {
+    notEmpty: { errorMessage: 'Verification code is required' },
+    isString: { errorMessage: 'Verification code must be a string' },
+    isLength: {
+      options: { min: 6, max: 6 },
+      errorMessage: 'Verification code must be 6 digits',
+    },
+  },
+  newPassword: {
+    notEmpty: { errorMessage: 'New password is required' },
+    isLength: {
+      options: { min: 6 },
+      errorMessage: 'New password must be at least 6 characters long',
+    },
+  },
+};
+
 module.exports = {
   signinValidatorSchema,
   signoutValidatorSchema,
   sendActivateEmailValidatorSchema,
   retrievePasswordValidatorSchema,
   createUserValidatorSchema,
+  changePasswordValidatorSchema,
 };

--- a/app/views/verification_code_mail.html
+++ b/app/views/verification_code_mail.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html style="margin: 0; padding: 0" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Verification Code</title>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #f0f0f0; font-family: Ubuntu, sans-serif">
+    <table
+      style="
+        border-collapse: collapse;
+        table-layout: fixed;
+        min-width: 320px;
+        width: 100%;
+        background-color: #f0f0f0;
+      "
+      cellpadding="0"
+      cellspacing="0"
+    >
+      <tbody>
+        <tr>
+          <td>
+            <div style="height: 20px"></div>
+            <div
+              style="
+                margin: 0 auto;
+                max-width: 600px;
+                min-width: 320px;
+                background-color: #ffffff;
+                padding: 40px 20px;
+              "
+            >
+              <h1
+                style="
+                  margin-top: 0;
+                  margin-bottom: 0;
+                  color: #565656;
+                  font-size: 30px;
+                  line-height: 38px;
+                  text-align: center;
+                "
+              >
+                <strong><%= siteName %></strong>
+              </h1>
+              <p style="margin-top: 20px; color: #787778; font-size: 16px; line-height: 24px">
+                Hi <strong><%= displayName %></strong>, you are changing your password. Please use
+                the verification code below within 5 minutes:
+              </p>
+              <div
+                style="
+                  margin: 30px auto;
+                  text-align: center;
+                  background-color: #f5f5f5;
+                  padding: 20px;
+                  border-radius: 8px;
+                  max-width: 300px;
+                "
+              >
+                <span
+                  style="
+                    font-size: 36px;
+                    font-weight: bold;
+                    letter-spacing: 8px;
+                    color: #448aff;
+                    font-family: monospace;
+                  "
+                  ><%= code %></span
+                >
+              </div>
+              <p style="color: grey; font-size: 14px; line-height: 22px">
+                If you did not request this change, please ignore this email and your password will
+                remain unchanged.
+              </p>
+              <div style="padding-top: 30px; padding-bottom: 20px">
+                <p
+                  style="
+                    margin-top: 0;
+                    color: #677483;
+                    font-size: 14px;
+                    line-height: 25px;
+                    margin-bottom: 0;
+                  "
+                >
+                  <em style="color: #a9b7c8; font-style: italic"><%= siteName %> team</em>
+                  <br />
+                  <a href="<%= siteUrl %>"><%= siteUrl %></a>
+                </p>
+              </div>
+            </div>
+            <div style="height: 40px"></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/unit/middlewares/rbacMiddleware.test.js
+++ b/tests/unit/middlewares/rbacMiddleware.test.js
@@ -1,0 +1,80 @@
+jest.mock('../../../app/services/authService');
+
+const AuthService = require('../../../app/services/authService');
+const { requirePermission } = require('../../../app/middlewares/rbacMiddleware');
+const CustomError = require('../../../app/utils/customError');
+
+describe('rbacMiddleware - requirePermission', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      userId: '507f1f77bcf86cd799439011',
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('should throw 401 when userId is not set on req', async () => {
+    req.userId = undefined;
+    const middleware = requirePermission('admin_purchase');
+
+    await expect(middleware(req, res, next)).rejects.toThrow(CustomError);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should throw 403 when user has no role', async () => {
+    AuthService.getUserPermission.mockResolvedValue({
+      role: null,
+      resources: [],
+    });
+    const middleware = requirePermission('admin_purchase');
+
+    await expect(middleware(req, res, next)).rejects.toThrow(CustomError);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should call next() when user has admin role (bypass)', async () => {
+    AuthService.getUserPermission.mockResolvedValue({
+      role: { _id: 'role-1', role_name: 'admin', role_description: 'Administrator' },
+      resources: [],
+    });
+    const middleware = requirePermission('admin_purchase');
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should call next() when user has the required resource_code', async () => {
+    AuthService.getUserPermission.mockResolvedValue({
+      role: { _id: 'role-2', role_name: 'editor', role_description: 'Editor' },
+      resources: [
+        { _id: 'res-1', resource_code: 'admin_purchase', resource_name: 'Purchases' },
+        { _id: 'res-2', resource_code: 'admin_role', resource_name: 'Roles' },
+      ],
+    });
+    const middleware = requirePermission('admin_purchase');
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should throw 403 when user lacks the required resource_code', async () => {
+    AuthService.getUserPermission.mockResolvedValue({
+      role: { _id: 'role-2', role_name: 'editor', role_description: 'Editor' },
+      resources: [{ _id: 'res-2', resource_code: 'admin_role', resource_name: 'Roles' }],
+    });
+    const middleware = requirePermission('admin_purchase');
+
+    await expect(middleware(req, res, next)).rejects.toThrow(CustomError);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/authService.test.js
+++ b/tests/unit/services/authService.test.js
@@ -1,6 +1,7 @@
 jest.mock('../../../app/models/portalTokenModel');
 jest.mock('../../../app/models/portalUserModel');
 jest.mock('../../../app/models/portalEmailInfoModel');
+jest.mock('../../../app/models/portalRoleModel');
 jest.mock('../../../app/services/userService');
 jest.mock('../../../app/services/sequenceService');
 jest.mock('../../../app/services/emailService');
@@ -520,6 +521,163 @@ describe('AuthService', () => {
         'SMTP connection error'
       );
       expect(result.message).toBe('Activation email will be sent!');
+    });
+  });
+
+  describe('sendVerificationCode()', () => {
+    it('should throw when user not found', async () => {
+      PortalUserModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(AuthService.sendVerificationCode('bad-id')).rejects.toThrow();
+    });
+
+    it('should throw rate limit when code was recently sent', async () => {
+      PortalUserModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'user-id',
+          email: 'test@test.com',
+          nick_name: 'Test',
+        }),
+      });
+      PortalTokenModel.findOne.mockResolvedValue({
+        _id: 'token-id',
+        last_access_time: Date.now(), // just now
+      });
+
+      await expect(AuthService.sendVerificationCode('user-id')).rejects.toThrow();
+    });
+
+    it('should send verification code email successfully', async () => {
+      PortalUserModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'user-id',
+          email: 'test@test.com',
+          nick_name: 'Test',
+        }),
+      });
+      PortalTokenModel.findOne.mockResolvedValue(null); // no existing token
+
+      const mockSave = jest.fn().mockResolvedValue(true);
+      PortalTokenModel.mockImplementation(() => ({ save: mockSave }));
+
+      PortalEmailInfoModel.STATUS_FAILED = 'failed';
+      EmailService.sendEmail.mockResolvedValue({ emailStatus: 'success' });
+
+      const result = await AuthService.sendVerificationCode('user-id');
+
+      expect(result.message).toBe('Verification code email will be sent!');
+      expect(EmailService.sendEmail).toHaveBeenCalled();
+    });
+  });
+
+  describe('changePassword()', () => {
+    it('should throw when verification code is invalid', async () => {
+      PortalTokenModel.findOne.mockResolvedValue(null);
+
+      await expect(AuthService.changePassword('user-id', '000000', 'newpass')).rejects.toThrow();
+    });
+
+    it('should throw when verification code is expired', async () => {
+      PortalTokenModel.findOne.mockResolvedValue({
+        _id: 'token-id',
+        user_id: 'user-id',
+        last_access_time: Date.now() - 2000 * 1000, // expired
+      });
+      PortalTokenModel.deleteOne.mockResolvedValue({});
+
+      await expect(AuthService.changePassword('user-id', '123456', 'newpass')).rejects.toThrow();
+    });
+
+    it('should change password successfully', async () => {
+      PortalTokenModel.findOne.mockResolvedValue({
+        _id: 'token-id',
+        user_id: 'user-id',
+        last_access_time: Date.now(), // fresh
+      });
+
+      const mockUser = {
+        _id: 'user-id',
+        password: 'old-hash',
+        salt: 'old-salt',
+        save: jest.fn().mockResolvedValue(true),
+      };
+      PortalUserModel.findById.mockResolvedValue(mockUser);
+      UserService.generatePassword.mockResolvedValue({
+        salt: 'new-salt',
+        password: 'new-hash',
+      });
+      PortalTokenModel.deleteOne.mockResolvedValue({});
+
+      const result = await AuthService.changePassword('user-id', '123456', 'newpass123');
+
+      expect(UserService.generatePassword).toHaveBeenCalledWith('newpass123');
+      expect(mockUser.password).toBe('new-hash');
+      expect(mockUser.salt).toBe('new-salt');
+      expect(mockUser.save).toHaveBeenCalled();
+      expect(result.message).toBe('Password changed successfully');
+    });
+  });
+
+  describe('getUserPermission()', () => {
+    const PortalRoleModel = require('../../../app/models/portalRoleModel');
+
+    it('should return null role and empty resources when user not found', async () => {
+      PortalUserModel.findById.mockReturnValue({
+        populate: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue(null),
+        }),
+      });
+
+      const result = await AuthService.getUserPermission('nonexistent-id');
+
+      expect(result.role).toBeNull();
+      expect(result.resources).toEqual([]);
+    });
+
+    it('should return null role and empty resources when user has no role', async () => {
+      PortalUserModel.findById.mockReturnValue({
+        populate: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ _id: 'user-id', role: null }),
+        }),
+      });
+
+      const result = await AuthService.getUserPermission('user-id');
+
+      expect(result.role).toBeNull();
+      expect(result.resources).toEqual([]);
+    });
+
+    it('should return role and resources when user has a role', async () => {
+      const mockResources = [
+        { _id: 'res-1', resource_code: 'admin_purchase', resource_name: 'Purchases' },
+        { _id: 'res-2', resource_code: 'admin_role', resource_name: 'Roles' },
+      ];
+      const mockRole = {
+        _id: 'role-1',
+        role_name: 'admin',
+        role_description: 'Administrator',
+        resource: mockResources,
+      };
+
+      PortalUserModel.findById.mockReturnValue({
+        populate: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ _id: 'user-id', role: { _id: 'role-1' } }),
+        }),
+      });
+
+      PortalRoleModel.findById.mockReturnValue({
+        populate: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue(mockRole),
+        }),
+      });
+
+      const result = await AuthService.getUserPermission('user-id');
+
+      expect(result.role.role_name).toBe('admin');
+      expect(result.resources).toHaveLength(2);
+      expect(result.resources[0].resource_code).toBe('admin_purchase');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Change Password API**: `POST /api/v1/auth/send-code` sends a 6-digit verification code to the authenticated user's email, `POST /api/v1/auth/change-password` verifies the code and updates the password (PBKDF2 hash)
- **RBAC Permission Checking**: `GET /api/v1/auth/permissions` returns the user's role and resource list, `requirePermission(resourceCode)` middleware factory for protecting admin routes
- **User Model**: Uncommented `role` field (ObjectId ref to `portal_role`) to support RBAC role assignment

## Changes

| File | Change |
|------|--------|
| `app/utils/statusCodes.js` | Added `PORTAL_VERIFICATION_CODE_INVALID (11017)` and `PORTAL_VERIFICATION_CODE_EXPIRED (11018)` with EN/ZH messages |
| `app/models/portalUserModel.js` | Enabled `role` field as ObjectId ref to `portal_role` |
| `app/services/authService.js` | Added `sendVerificationCode()`, `changePassword()`, `getUserPermission()` |
| `app/controllers/authController.js` | Added `sendCode()`, `changePassword()`, `permissions()` |
| `app/validators/authValidator.js` | Added `changePasswordValidatorSchema` |
| `app/routes/authRoutes.js` | Added 3 new endpoints with Swagger docs |
| `app/middlewares/rbacMiddleware.js` | New — `requirePermission()` middleware factory |
| `app/views/verification_code_mail.html` | New — EJS email template for verification code |
| `tests/unit/services/authService.test.js` | Added 8 tests for new methods |
| `tests/unit/middlewares/rbacMiddleware.test.js` | New — 5 tests for RBAC middleware |

## Test plan

- [x] All 267 tests passing (24 suites) — up from 253
- [ ] Manual test: send-code → receive email → change-password flow
- [ ] Manual test: assign role to user → verify permissions endpoint
- [ ] Manual test: apply requirePermission to admin route → verify access control

🤖 Generated with [Claude Code](https://claude.com/claude-code)