### PR TITLE
feat: monitoring & observability - health check, graceful shutdown, scheduler registry

### DIFF
--- a/app/controllers/homeController.js
+++ b/app/controllers/homeController.js
@@ -1,6 +1,15 @@
+const mongoose = require('mongoose');
 const { hashidsEncode, hashidsDecode } = require('../utils/hashidsHandler');
 const HomeService = require('../services/homeService');
 const ResponseHandler = require('../utils/responseHandler');
+const { getStatus: getSchedulerStatus } = require('../utils/schedulerRegistry');
+
+const READY_STATE_MAP = {
+  0: 'disconnected',
+  1: 'connected',
+  2: 'connecting',
+  3: 'disconnecting',
+};
 
 class HomeController {
   async index(req, res) {
@@ -13,10 +22,37 @@ class HomeController {
     res.json({ x, y });
   }
 
-  // Route to check the status of the scheduled task
-  async checkTask(req, res) {
-    // const taskStatus = task.getStatus(); // Returns the status of the scheduled task
-    res.json({ status: true });
+  async health(req, res) {
+    const { readyState } = mongoose.connection;
+    const mongoStatus = READY_STATE_MAP[readyState] || 'disconnected';
+
+    let status = 'ok';
+    if (readyState === 0) {
+      status = 'error';
+    } else if (readyState === 2 || readyState === 3) {
+      status = 'degraded';
+    }
+
+    const memUsage = process.memoryUsage();
+
+    const body = {
+      status,
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+      mongodb: {
+        status: mongoStatus,
+        readyState,
+      },
+      memory: {
+        rss: memUsage.rss,
+        heapUsed: memUsage.heapUsed,
+        heapTotal: memUsage.heapTotal,
+      },
+      schedulers: getSchedulerStatus(),
+    };
+
+    const httpCode = status === 'ok' ? 200 : 503;
+    res.status(httpCode).json(body);
   }
 
   /**

--- a/app/routes/homeRoutes.js
+++ b/app/routes/homeRoutes.js
@@ -49,25 +49,37 @@ router.get('/test', HomeController.test);
 
 /**
  * @swagger
- * /check-task:
+ * /health:
  *   get:
- *     summary: Check scheduled tasks
+ *     summary: Health check endpoint
  *     tags:
  *       - Home
- *     description: Checks the status of background tasks or scheduled jobs.
+ *     description: Returns system health including MongoDB status, memory usage, uptime, and scheduler statuses.
  *     responses:
  *       200:
- *         description: Task check successful
+ *         description: System is healthy
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 tasksRunning:
- *                   type: boolean
- *                   example: true
+ *                 status:
+ *                   type: string
+ *                   example: "ok"
+ *                 uptime:
+ *                   type: number
+ *                 timestamp:
+ *                   type: string
+ *                 mongodb:
+ *                   type: object
+ *                 memory:
+ *                   type: object
+ *                 schedulers:
+ *                   type: object
+ *       503:
+ *         description: System is degraded or in error state
  */
-router.get('/check-task', HomeController.checkTask);
+router.get('/health', HomeController.health);
 
 /**
  * @swagger

--- a/app/schedulers/btcHistoryScheduler.js
+++ b/app/schedulers/btcHistoryScheduler.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const HomeService = require('../services/homeService');
 const logger = require('../utils/logger');
+const { recordStart, recordSuccess, recordFailure } = require('../utils/schedulerRegistry');
 
 let isRunning = false;
 
@@ -12,10 +13,13 @@ const btcHistoryScheduler = () => {
       return;
     }
     isRunning = true;
+    recordStart('btcHistory');
     try {
       logger.info(`btcHistoryScheduler: running at ${new Date().toISOString()}`);
       await HomeService.fetchAndStoreBtcPrice();
+      recordSuccess('btcHistory');
     } catch (error) {
+      recordFailure('btcHistory', error);
       logger.error(`btcHistoryScheduler: error - ${error.message}`);
     } finally {
       isRunning = false;

--- a/app/schedulers/buyScheduler.js
+++ b/app/schedulers/buyScheduler.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const StrategyService = require('../services/strategyService');
 const logger = require('../utils/logger');
+const { recordStart, recordSuccess, recordFailure } = require('../utils/schedulerRegistry');
 
 let isRunning = false;
 
@@ -12,10 +13,13 @@ const buyScheduler = () => {
       return;
     }
     isRunning = true;
+    recordStart('buy');
     try {
       logger.info(`Running Task Buy schedule at ${new Date().toLocaleString()}`);
       await StrategyService.executeAllBuys();
+      recordSuccess('buy');
     } catch (error) {
+      recordFailure('buy', error);
       logger.error(`Error running buyScheduler: ${error.message}`);
     } finally {
       isRunning = false;

--- a/app/schedulers/priceScheduler.js
+++ b/app/schedulers/priceScheduler.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const SymbolService = require('../services/symbolService');
 const logger = require('../utils/logger');
+const { recordStart, recordSuccess, recordFailure } = require('../utils/schedulerRegistry');
 
 const priceScheduler = () => {
   cron.schedule('0 0 * * *', async () => {
@@ -9,12 +10,14 @@ const priceScheduler = () => {
     const yesterday = new Date(today);
     yesterday.setDate(yesterday.getDate() - 1);
     const startDate = yesterday.toISOString().split('T')[0];
-    
+
     logger.info(`PriceScheduler for ${startDate}`);
-    // todo: add status code for schedulers
+    recordStart('price');
     try {
       await SymbolService.getPrice(startDate, endDate, 'binance', 'BTC/USDT');
+      recordSuccess('price');
     } catch (error) {
+      recordFailure('price', error);
       logger.error(`Error running PriceScheduler: ${error.message}`);
     }
   });

--- a/app/schedulers/sellScheduler.js
+++ b/app/schedulers/sellScheduler.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const StrategyService = require('../services/strategyService');
 const logger = require('../utils/logger');
+const { recordStart, recordSuccess, recordFailure } = require('../utils/schedulerRegistry');
 
 let isRunning = false;
 
@@ -11,10 +12,13 @@ const sellScheduler = () => {
       return;
     }
     isRunning = true;
+    recordStart('sell');
     try {
       logger.info('Running Task One at 6 AM every day.');
       await StrategyService.executeAllSells();
+      recordSuccess('sell');
     } catch (error) {
+      recordFailure('sell', error);
       logger.error(`Error running sellScheduler: ${error.message}`);
     } finally {
       isRunning = false;

--- a/app/schedulers/sellThirdPartyScheduler.js
+++ b/app/schedulers/sellThirdPartyScheduler.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const StrategyService = require('../services/strategyService');
 const logger = require('../utils/logger');
+const { recordStart, recordSuccess, recordFailure } = require('../utils/schedulerRegistry');
 
 let isRunning = false;
 
@@ -11,10 +12,13 @@ const sellThirdPartyScheduler = () => {
       return;
     }
     isRunning = true;
+    recordStart('sellThirdParty');
     try {
       logger.info('Running Task One at 6 PM every day.');
       await StrategyService.sellAllOrders();
+      recordSuccess('sellThirdParty');
     } catch (error) {
+      recordFailure('sellThirdParty', error);
       logger.error(`Error running sellThirdPartyScheduler: ${error.message}`);
     } finally {
       isRunning = false;

--- a/app/schedulers/tickerScheduler.js
+++ b/app/schedulers/tickerScheduler.js
@@ -3,6 +3,7 @@ const ccxt = require('ccxt');
 const ArbitrageTickerModel = require('../models/arbitrageTickerModel');
 const ArbitrageConfigModel = require('../models/arbitrageConfigModel');
 const logger = require('../utils/logger');
+const { recordStart, recordSuccess, recordFailure } = require('../utils/schedulerRegistry');
 
 const DEFAULT_EXCHANGES = ['binance', 'huobi', 'okx'];
 const DEFAULT_SYMBOLS = ['BTC/USDT', 'ETH/USDT'];
@@ -86,10 +87,13 @@ const tickerScheduler = () => {
       return;
     }
     isRunning = true;
+    recordStart('ticker');
     try {
       logger.info(`[tickerScheduler] Starting ticker fetch at ${new Date().toISOString()}`);
       await fetchAllTickers();
+      recordSuccess('ticker');
     } catch (error) {
+      recordFailure('ticker', error);
       logger.error(`[tickerScheduler] Error: ${error.message}`);
     } finally {
       isRunning = false;

--- a/app/utils/schedulerRegistry.js
+++ b/app/utils/schedulerRegistry.js
@@ -1,0 +1,50 @@
+const registry = {};
+
+function recordStart(schedulerName) {
+  if (!registry[schedulerName]) {
+    registry[schedulerName] = {
+      lastRun: null,
+      lastSuccess: null,
+      lastFailure: null,
+      lastError: null,
+      isRunning: false,
+    };
+  }
+  registry[schedulerName].lastRun = new Date().toISOString();
+  registry[schedulerName].isRunning = true;
+}
+
+function recordSuccess(schedulerName) {
+  if (!registry[schedulerName]) {
+    registry[schedulerName] = {
+      lastRun: null,
+      lastSuccess: null,
+      lastFailure: null,
+      lastError: null,
+      isRunning: false,
+    };
+  }
+  registry[schedulerName].lastSuccess = new Date().toISOString();
+  registry[schedulerName].isRunning = false;
+}
+
+function recordFailure(schedulerName, error) {
+  if (!registry[schedulerName]) {
+    registry[schedulerName] = {
+      lastRun: null,
+      lastSuccess: null,
+      lastFailure: null,
+      lastError: null,
+      isRunning: false,
+    };
+  }
+  registry[schedulerName].lastFailure = new Date().toISOString();
+  registry[schedulerName].lastError = error?.message || String(error);
+  registry[schedulerName].isRunning = false;
+}
+
+function getStatus() {
+  return { ...registry };
+}
+
+module.exports = { recordStart, recordSuccess, recordFailure, getStatus };

--- a/app/utils/schedulerRegistry.js
+++ b/app/utils/schedulerRegistry.js
@@ -1,6 +1,6 @@
 const registry = {};
 
-function recordStart(schedulerName) {
+function ensureEntry(schedulerName) {
   if (!registry[schedulerName]) {
     registry[schedulerName] = {
       lastRun: null,
@@ -10,41 +10,30 @@ function recordStart(schedulerName) {
       isRunning: false,
     };
   }
-  registry[schedulerName].lastRun = new Date().toISOString();
-  registry[schedulerName].isRunning = true;
+  return registry[schedulerName];
+}
+
+function recordStart(schedulerName) {
+  const entry = ensureEntry(schedulerName);
+  entry.lastRun = new Date().toISOString();
+  entry.isRunning = true;
 }
 
 function recordSuccess(schedulerName) {
-  if (!registry[schedulerName]) {
-    registry[schedulerName] = {
-      lastRun: null,
-      lastSuccess: null,
-      lastFailure: null,
-      lastError: null,
-      isRunning: false,
-    };
-  }
-  registry[schedulerName].lastSuccess = new Date().toISOString();
-  registry[schedulerName].isRunning = false;
+  const entry = ensureEntry(schedulerName);
+  entry.lastSuccess = new Date().toISOString();
+  entry.isRunning = false;
 }
 
 function recordFailure(schedulerName, error) {
-  if (!registry[schedulerName]) {
-    registry[schedulerName] = {
-      lastRun: null,
-      lastSuccess: null,
-      lastFailure: null,
-      lastError: null,
-      isRunning: false,
-    };
-  }
-  registry[schedulerName].lastFailure = new Date().toISOString();
-  registry[schedulerName].lastError = error?.message || String(error);
-  registry[schedulerName].isRunning = false;
+  const entry = ensureEntry(schedulerName);
+  entry.lastFailure = new Date().toISOString();
+  entry.lastError = error?.message || String(error);
+  entry.isRunning = false;
 }
 
 function getStatus() {
-  return { ...registry };
+  return JSON.parse(JSON.stringify(registry));
 }
 
 module.exports = { recordStart, recordSuccess, recordFailure, getStatus };

--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,8 @@
 var app = require('../app');
 var debug = require('debug')('moow:server');
 var http = require('http');
+var mongoose = require('mongoose');
+var logger = require('../app/utils/logger');
 
 /**
  * Get port from environment and store in Express.
@@ -84,3 +86,34 @@ function onListening() {
   var bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
   debug('Listening on ' + bind);
 }
+
+/**
+ * Graceful shutdown handler.
+ */
+
+function gracefulShutdown(signal) {
+  logger.info(`Received ${signal}. Starting graceful shutdown...`);
+
+  // Stop accepting new connections
+  server.close(() => {
+    logger.info('HTTP server closed');
+
+    // Close MongoDB connection
+    mongoose.connection.close().then(() => {
+      logger.info('MongoDB connection closed');
+      process.exit(0);
+    }).catch((err) => {
+      logger.error('Error closing MongoDB connection:', err);
+      process.exit(1);
+    });
+  });
+
+  // Force shutdown after 10 seconds if in-flight requests don't finish
+  setTimeout(() => {
+    logger.error('Graceful shutdown timed out after 10s, forcing exit');
+    process.exit(1);
+  }, 10000);
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));

--- a/bin/www
+++ b/bin/www
@@ -109,10 +109,11 @@ function gracefulShutdown(signal) {
   });
 
   // Force shutdown after 10 seconds if in-flight requests don't finish
-  setTimeout(() => {
+  const shutdownTimer = setTimeout(() => {
     logger.error('Graceful shutdown timed out after 10s, forcing exit');
     process.exit(1);
   }, 10000);
+  shutdownTimer.unref();
 }
 
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));

--- a/config/db.js
+++ b/config/db.js
@@ -11,9 +11,25 @@ const connectDB = async () => {
     });
     logger.info(`Connected to MongoDB at ${config.mongoUri}`);
   } catch (err) {
-    logger.info('MongoDB connection error:', err.message);
+    logger.error('MongoDB connection error:', err.message);
     process.exit(1); // 结束进程
   }
+
+  mongoose.connection.on('connected', () => {
+    logger.info('MongoDB connected');
+  });
+
+  mongoose.connection.on('disconnected', () => {
+    logger.warn('MongoDB disconnected');
+  });
+
+  mongoose.connection.on('error', (err) => {
+    logger.error('MongoDB connection error:', err);
+  });
+
+  mongoose.connection.on('reconnected', () => {
+    logger.info('MongoDB reconnected');
+  });
 };
 
 module.exports = connectDB;

--- a/config/middleware.js
+++ b/config/middleware.js
@@ -4,6 +4,8 @@ const cors = require('cors');
 const compression = require('compression');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
+const responseTime = require('response-time');
+const { v4: uuidv4 } = require('uuid');
 const session = require('./session');
 const config = require('./index');
 const logger = require('../app/utils/logger');
@@ -32,6 +34,21 @@ const setupMiddleware = (app) => {
     })
   );
   app.use(compression());
+
+  // Response time header
+  app.use(responseTime());
+
+  // Request correlation IDs
+  app.use((req, res, next) => {
+    const requestId = req.headers['x-request-id'] || uuidv4();
+    req.requestId = requestId;
+    res.setHeader('X-Request-Id', requestId);
+    next();
+  });
+
+  // Custom Morgan token for request ID
+  morgan.token('request-id', (req) => req.requestId);
+
   app.use('/api/v1/auth', authLimiter);
   app.use('/api/v1', apiLimiter);
   app.use(session);
@@ -44,7 +61,9 @@ const setupMiddleware = (app) => {
   if (config.env === 'development') {
     app.use(morgan('dev'));
   } else if (config.env === 'production') {
-    app.use(morgan('combined', { stream: logger.stream }));
+    app.use(
+      morgan(':request-id :remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"', { stream: logger.stream })
+    );
   } else {
     app.use(morgan('tiny', { stream: logger.stream }));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "node-cache": "^5.1.2",
         "node-cron": "^3.0.3",
         "nodemailer": "^6.9.13",
+        "response-time": "^2.3.4",
         "svg-captcha": "^1.4.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
@@ -12568,6 +12569,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/response-time": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.4.tgz",
+      "integrity": "sha512-fiyq1RvW5/Br6iAtT8jN1XrNY8WPu2+yEypLbaijWry8WDZmn12azG9p/+c+qpEebURLlQmqCB8BNSu7ji+xQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node-cache": "^5.1.2",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.13",
+    "response-time": "^2.3.4",
     "svg-captcha": "^1.4.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",


### PR DESCRIPTION
## Summary
- **Health check endpoint** (`GET /health`): Returns MongoDB status, memory usage, scheduler statuses, uptime. HTTP 200 for ok, 503 for degraded/error
- **Graceful shutdown**: SIGTERM/SIGINT handlers — stops new connections, closes MongoDB, 10s forced timeout with `.unref()`
- **MongoDB connection events**: Logs connected/disconnected/error/reconnected events. Fixed error log level from info→error
- **Scheduler status registry**: In-memory tracker for all 6 schedulers (buy, sell, sellThirdParty, price, ticker, btcHistory) — records lastRun, lastSuccess, lastFailure, lastError, isRunning
- **Request correlation IDs**: UUID per request (uses incoming X-Request-Id or generates new), attached to response header and included in production Morgan logs
- **Response time header**: `X-Response-Time` via `response-time` package

## Files Changed (14 files, +210 -16)
- `app/controllers/homeController.js` — Health endpoint controller
- `app/routes/homeRoutes.js` — `GET /health` route (replaces `/check-task`)
- `bin/www` — Graceful shutdown handlers
- `config/db.js` — Connection event handlers + log level fix
- `app/utils/schedulerRegistry.js` — New: scheduler status registry (DRY with ensureEntry helper)
- `app/schedulers/*.js` — All 6 schedulers instrumented with registry calls
- `config/middleware.js` — Correlation IDs, response-time, custom Morgan format

## Test plan
- [x] All 268 tests pass
- [ ] Verify `GET /health` returns correct JSON with MongoDB status
- [ ] Verify `X-Request-Id` and `X-Response-Time` headers in API responses
- [ ] Verify graceful shutdown on SIGTERM (docker stop / kill -TERM)
- [ ] Verify scheduler statuses appear in health endpoint after scheduler runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)