### PR TITLE
test: add 10 test files to improve coverage from 59% to 83%

### DIFF
--- a/tests/integration/home.test.js
+++ b/tests/integration/home.test.js
@@ -1,0 +1,184 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { connect, closeDatabase, clearDatabase } = require('../helpers/db');
+
+// Mock email service to avoid sending real emails
+jest.mock('../../app/services/emailService', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ emailStatus: 1 }),
+}));
+
+// Mock logger to reduce noise
+jest.mock('../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  stream: { write: jest.fn() },
+}));
+
+// Mock schedulerRegistry so /health doesn't depend on real schedulers
+jest.mock('../../app/utils/schedulerRegistry', () => ({
+  getStatus: jest.fn().mockReturnValue([]),
+  register: jest.fn(),
+}));
+
+const createTestApp = require('../helpers/app');
+const DataBtcHistoryModel = require('../../app/models/dataBtcHistoryModel');
+const CommonConfigModel = require('../../app/models/commonConfigModel');
+const AipOrderModel = require('../../app/models/aipOrderModel');
+
+let app;
+
+beforeAll(async () => {
+  await connect();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+afterEach(async () => {
+  await clearDatabase();
+});
+
+describe('Home API Integration', () => {
+  describe('GET /', () => {
+    it('should return service live message', async () => {
+      const res = await request(app).get('/');
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('service is live');
+    });
+  });
+
+  describe('GET /test', () => {
+    it('should return hashids encode/decode result', async () => {
+      const res = await request(app).get('/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('x');
+      expect(res.body).toHaveProperty('y');
+      // hashidsEncode(1) should produce a string, hashidsDecode should return 1
+      expect(typeof res.body.x).toBe('string');
+      expect(res.body.y).toBe(1);
+    });
+  });
+
+  describe('GET /health', () => {
+    it('should return health check with status ok when connected', async () => {
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ok');
+      expect(res.body).toHaveProperty('uptime');
+      expect(res.body).toHaveProperty('timestamp');
+      expect(res.body).toHaveProperty('mongodb');
+      expect(res.body.mongodb.status).toBe('connected');
+      expect(res.body).toHaveProperty('memory');
+      expect(res.body.memory).toHaveProperty('rss');
+      expect(res.body.memory).toHaveProperty('heapUsed');
+    });
+  });
+
+  describe('GET /api/v1/public/btc-history', () => {
+    it('should return empty list when no data exists', async () => {
+      const res = await request(app).get('/api/v1/public/btc-history');
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toEqual([]);
+    });
+
+    it('should return BTC history data sorted chronologically', async () => {
+      // Seed BTC history data
+      await DataBtcHistoryModel.create([
+        { date: '2025-01-01', open: 40000, high: 41000, low: 39000, close: 40500, volume: 1000 },
+        { date: '2025-01-02', open: 40500, high: 42000, low: 40000, close: 41500, volume: 1200 },
+        { date: '2025-01-03', open: 41500, high: 43000, low: 41000, close: 42000, volume: 1100 },
+      ]);
+
+      const res = await request(app).get('/api/v1/public/btc-history');
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toHaveLength(3);
+      // Should be in chronological order (oldest first)
+      expect(res.body.data.list[0].date).toBe('2025-01-01');
+      expect(res.body.data.list[2].date).toBe('2025-01-03');
+    });
+
+    it('should respect the limit query parameter', async () => {
+      await DataBtcHistoryModel.create([
+        { date: '2025-01-01', open: 40000, high: 41000, low: 39000, close: 40500, volume: 1000 },
+        { date: '2025-01-02', open: 40500, high: 42000, low: 40000, close: 41500, volume: 1200 },
+        { date: '2025-01-03', open: 41500, high: 43000, low: 41000, close: 42000, volume: 1100 },
+      ]);
+
+      const res = await request(app).get('/api/v1/public/btc-history?limit=2');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.list).toHaveLength(2);
+    });
+  });
+
+  describe('GET /api/v1/public/dingtou/orders', () => {
+    it('should return empty list when no config exists', async () => {
+      const res = await request(app).get('/api/v1/public/dingtou/orders');
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toEqual([]);
+    });
+
+    it('should return orders for the configured dingtou strategy', async () => {
+      const strategyId = new mongoose.Types.ObjectId().toString();
+
+      // Seed the dingtou_id config
+      await CommonConfigModel.create({
+        name: 'dingtou_id',
+        content: strategyId,
+      });
+
+      // Seed some orders for this strategy
+      await AipOrderModel.create([
+        {
+          strategy_id: strategyId,
+          order_id: 'order-1',
+          type: 'market',
+          side: 'buy',
+          price: '50000',
+          amount: '0.002',
+          symbol: 'BTC/USDT',
+        },
+        {
+          strategy_id: strategyId,
+          order_id: 'order-2',
+          type: 'market',
+          side: 'buy',
+          price: '51000',
+          amount: '0.002',
+          symbol: 'BTC/USDT',
+        },
+      ]);
+
+      const res = await request(app).get('/api/v1/public/dingtou/orders');
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toHaveLength(2);
+      expect(res.body.data.list[0]).toHaveProperty('strategy_id', strategyId);
+    });
+
+    it('should return empty list when strategy has no orders', async () => {
+      await CommonConfigModel.create({
+        name: 'dingtou_id',
+        content: new mongoose.Types.ObjectId().toString(),
+      });
+
+      const res = await request(app).get('/api/v1/public/dingtou/orders');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.list).toEqual([]);
+    });
+  });
+});

--- a/tests/integration/market.test.js
+++ b/tests/integration/market.test.js
@@ -1,0 +1,262 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { connect, closeDatabase, clearDatabase } = require('../helpers/db');
+
+// Mock email service to avoid sending real emails
+jest.mock('../../app/services/emailService', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ emailStatus: 1 }),
+}));
+
+// Mock logger to reduce noise
+jest.mock('../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  stream: { write: jest.fn() },
+}));
+
+const createTestApp = require('../helpers/app');
+const PortalUserModel = require('../../app/models/portalUserModel');
+const PortalTokenModel = require('../../app/models/portalTokenModel');
+const PortalMarketModel = require('../../app/models/portalMarketModel');
+
+let app;
+
+beforeAll(async () => {
+  await connect();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+afterEach(async () => {
+  await clearDatabase();
+});
+
+/**
+ * Helper: create an authenticated user with token.
+ * Returns { userId, tokenDoc }.
+ */
+const createAuthUser = async () => {
+  const userId = new mongoose.Types.ObjectId();
+  await PortalUserModel.create({
+    _id: userId,
+    nick_name: 'MarketTestUser',
+    email: `market-test-${Date.now()}@test.com`,
+    password: 'hashed',
+    salt: `salt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    seq_id: Math.floor(Math.random() * 100000),
+  });
+  const tokenDoc = await PortalTokenModel.create({
+    user_id: userId,
+    token: `market-token-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type: 'session',
+    last_access_time: new Date(),
+  });
+  return { userId, tokenDoc };
+};
+
+describe('Market API Integration', () => {
+  describe('GET /api/v1/markets', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).get('/api/v1/markets');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return list of markets', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      // Seed markets
+      await PortalMarketModel.create([
+        { name: 'Binance', exchange: `binance-${Date.now()}`, is_deleted: false },
+        { name: 'OKX', exchange: `okx-${Date.now()}`, is_deleted: false },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/markets')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toHaveLength(2);
+      expect(res.body.data).toHaveProperty('total', 2);
+    });
+
+    it('should not return soft-deleted markets', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      await PortalMarketModel.create([
+        { name: 'Active Market', exchange: `active-${Date.now()}`, is_deleted: false },
+        { name: 'Deleted Market', exchange: `deleted-${Date.now()}`, is_deleted: true },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/markets')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.list).toHaveLength(1);
+      expect(res.body.data.list[0].name).toBe('Active Market');
+    });
+  });
+
+  describe('POST /api/v1/markets', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).post('/api/v1/markets').send({
+        name: 'TestExchange',
+        exchange: 'testexchange',
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should create a new market', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const exchangeName = `newexchange-${Date.now()}`;
+
+      const res = await request(app)
+        .post('/api/v1/markets')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({
+          name: 'New Exchange',
+          exchange: exchangeName,
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data).toHaveProperty('_id');
+
+      // Verify in DB
+      const market = await PortalMarketModel.findById(res.body.data._id);
+      expect(market).not.toBeNull();
+      expect(market.name).toBe('New Exchange');
+      expect(market.exchange).toBe(exchangeName);
+    });
+
+    it('should reject creation with missing required fields', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .post('/api/v1/markets')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({
+          // Missing name and exchange
+        });
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('GET /api/v1/markets/:id', () => {
+    it('should return a market by ID', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const market = await PortalMarketModel.create({
+        name: 'Binance',
+        exchange: `binance-show-${Date.now()}`,
+        url: 'https://binance.com',
+      });
+
+      const res = await request(app)
+        .get(`/api/v1/markets/${market._id}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.name).toBe('Binance');
+    });
+
+    it('should return error for non-existent market', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .get(`/api/v1/markets/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('PUT /api/v1/markets/:id', () => {
+    it('should update a market', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const market = await PortalMarketModel.create({
+        name: 'Old Name',
+        exchange: `oldexchange-${Date.now()}`,
+      });
+
+      const res = await request(app)
+        .put(`/api/v1/markets/${market._id}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({ name: 'Updated Name' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data).toHaveProperty('_id');
+
+      // Verify in DB
+      const updated = await PortalMarketModel.findById(market._id).lean();
+      expect(updated.name).toBe('Updated Name');
+    });
+
+    it('should return error when updating non-existent market', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .put(`/api/v1/markets/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({ name: 'Updated' });
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('DELETE /api/v1/markets/:id', () => {
+    it('should soft delete a market', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const market = await PortalMarketModel.create({
+        name: 'ToDelete',
+        exchange: `todelete-${Date.now()}`,
+      });
+
+      const res = await request(app)
+        .delete(`/api/v1/markets/${market._id}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+
+      // Verify soft delete in DB
+      const deleted = await PortalMarketModel.findById(market._id).lean();
+      expect(deleted.is_deleted).toBe(true);
+    });
+
+    it('should return error when deleting non-existent market', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .delete(`/api/v1/markets/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+});

--- a/tests/integration/purchase.test.js
+++ b/tests/integration/purchase.test.js
@@ -1,0 +1,330 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { connect, closeDatabase, clearDatabase } = require('../helpers/db');
+
+// Mock email service to avoid sending real emails
+jest.mock('../../app/services/emailService', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ emailStatus: 1 }),
+}));
+
+// Mock logger to reduce noise
+jest.mock('../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  stream: { write: jest.fn() },
+}));
+
+const createTestApp = require('../helpers/app');
+const PortalUserModel = require('../../app/models/portalUserModel');
+const PortalTokenModel = require('../../app/models/portalTokenModel');
+const PortalRoleModel = require('../../app/models/portalRoleModel');
+const PurchaseModel = require('../../app/models/purchaseModel');
+
+let app;
+
+beforeAll(async () => {
+  await connect();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+afterEach(async () => {
+  await clearDatabase();
+});
+
+/**
+ * Helper: create a regular authenticated user (no admin role).
+ */
+const createAuthUser = async () => {
+  const userId = new mongoose.Types.ObjectId();
+  await PortalUserModel.create({
+    _id: userId,
+    nick_name: 'PurchaseUser',
+    email: `purchase-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`,
+    password: 'hashed',
+    salt: `salt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    seq_id: Math.floor(Math.random() * 100000),
+  });
+  const tokenDoc = await PortalTokenModel.create({
+    user_id: userId,
+    token: `purchase-token-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type: 'session',
+    last_access_time: new Date(),
+  });
+  return { userId, tokenDoc };
+};
+
+/**
+ * Helper: create an admin user with admin role (bypasses RBAC).
+ */
+const createAdminUser = async () => {
+  const adminRole = await PortalRoleModel.create({
+    role_name: 'admin',
+    role_description: 'Administrator',
+    resource: [],
+  });
+
+  const userId = new mongoose.Types.ObjectId();
+  await PortalUserModel.create({
+    _id: userId,
+    nick_name: 'AdminUser',
+    email: `admin-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`,
+    password: 'hashed',
+    salt: `salt-admin-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    seq_id: Math.floor(Math.random() * 100000),
+    role: adminRole._id,
+  });
+  const tokenDoc = await PortalTokenModel.create({
+    user_id: userId,
+    token: `admin-token-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type: 'session',
+    last_access_time: new Date(),
+  });
+  return { userId, tokenDoc };
+};
+
+describe('Purchase API Integration', () => {
+  describe('POST /api/v1/purchases', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).post('/api/v1/purchases').send({
+        eth_address: '0x123',
+        tx_hash: '0xabc',
+        amount: '0.1',
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should submit a purchase successfully', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .post('/api/v1/purchases')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({
+          eth_address: '0x1234567890abcdef',
+          tx_hash: '0xabcdef1234567890',
+          amount: '0.5',
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data).toHaveProperty('_id');
+
+      // Verify in DB
+      const purchase = await PurchaseModel.findById(res.body.data._id).lean();
+      expect(purchase).not.toBeNull();
+      expect(purchase.eth_address).toBe('0x1234567890abcdef');
+      expect(purchase.status).toBe('waiting');
+      expect(purchase.user.toString()).toBe(userId.toString());
+    });
+
+    it('should reject submission with missing required fields', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .post('/api/v1/purchases')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({
+          eth_address: '0x123',
+          // Missing tx_hash and amount
+        });
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('GET /api/v1/purchases', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .get('/api/v1/purchases')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return list of purchases for admin user', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+      const { userId: regularId } = await createAuthUser();
+
+      // Seed purchases
+      await PurchaseModel.create([
+        {
+          user: regularId,
+          eth_address: '0xaaa',
+          tx_hash: '0x111',
+          amount: '0.1',
+          email: 'test1@test.com',
+        },
+        {
+          user: regularId,
+          eth_address: '0xbbb',
+          tx_hash: '0x222',
+          amount: '0.2',
+          email: 'test2@test.com',
+        },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/purchases')
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toHaveLength(2);
+      expect(res.body.data).toHaveProperty('total', 2);
+    });
+  });
+
+  describe('GET /api/v1/purchases/:id', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .get(`/api/v1/purchases/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return purchase details for admin user', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+
+      const purchase = await PurchaseModel.create({
+        user: adminId,
+        eth_address: '0xdetails',
+        tx_hash: '0xdetailstx',
+        amount: '1.5',
+        email: 'details@test.com',
+      });
+
+      const res = await request(app)
+        .get(`/api/v1/purchases/${purchase._id}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.eth_address).toBe('0xdetails');
+      expect(res.body.data.amount).toBe('1.5');
+    });
+
+    it('should return error for non-existent purchase', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .get(`/api/v1/purchases/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('PATCH /api/v1/purchases/:id', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .patch(`/api/v1/purchases/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({ status: 'success' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should update purchase status for admin', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+
+      const purchase = await PurchaseModel.create({
+        user: adminId,
+        eth_address: '0xupdate',
+        tx_hash: '0xupdatetx',
+        amount: '0.3',
+      });
+
+      const res = await request(app)
+        .patch(`/api/v1/purchases/${purchase._id}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString())
+        .send({ status: 'success', comment: 'Verified on chain' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+
+      // Verify in DB
+      const updated = await PurchaseModel.findById(purchase._id).lean();
+      expect(updated.status).toBe('success');
+      expect(updated.comment).toBe('Verified on chain');
+    });
+  });
+
+  describe('POST /api/v1/purchases/:id/promote', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .post(`/api/v1/purchases/${fakeId}/promote`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should promote purchase and extend VIP for admin', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+
+      // Create a user whose VIP will be extended
+      const targetUser = await PortalUserModel.create({
+        nick_name: 'VIPUser',
+        email: `vip-${Date.now()}@test.com`,
+        password: 'hashed',
+        salt: `salt-vip-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        seq_id: Math.floor(Math.random() * 100000),
+        vip_time_out_at: new Date(),
+      });
+
+      const purchase = await PurchaseModel.create({
+        user: targetUser._id,
+        eth_address: '0xpromote',
+        tx_hash: '0xpromotetx',
+        amount: '0.5',
+      });
+
+      const res = await request(app)
+        .post(`/api/v1/purchases/${purchase._id}/promote`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data).toHaveProperty('vip_time_out_at');
+
+      // Verify purchase status changed to success
+      const updatedPurchase = await PurchaseModel.findById(purchase._id).lean();
+      expect(updatedPurchase.status).toBe('success');
+
+      // Verify user VIP was extended
+      const updatedUser = await PortalUserModel.findById(targetUser._id).lean();
+      expect(new Date(updatedUser.vip_time_out_at).getTime()).toBeGreaterThan(
+        new Date(targetUser.vip_time_out_at).getTime()
+      );
+    });
+  });
+});

--- a/tests/integration/symbol.test.js
+++ b/tests/integration/symbol.test.js
@@ -1,0 +1,239 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { connect, closeDatabase, clearDatabase } = require('../helpers/db');
+
+// Mock email service to avoid sending real emails
+jest.mock('../../app/services/emailService', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ emailStatus: 1 }),
+}));
+
+// Mock logger to reduce noise
+jest.mock('../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  stream: { write: jest.fn() },
+}));
+
+// Mock ccxt to avoid hitting real exchanges
+jest.mock('ccxt', () => {
+  const MockExchange = jest.fn(() => ({
+    fetchTicker: jest.fn().mockResolvedValue({
+      symbol: 'BTC/USDT',
+      ask: 50000,
+      bid: 49900,
+      last: 49950,
+    }),
+    fetchBalance: jest.fn().mockResolvedValue({
+      USDT: { free: 10000, used: 0, total: 10000 },
+    }),
+    fetchOHLCV: jest.fn().mockResolvedValue([[1704067200000, 42000, 43000, 41000, 42500, 1000]]),
+    urls: { www: 'https://binance.com', api: 'https://api.binance.com' },
+  }));
+  return {
+    binance: MockExchange,
+    okex: MockExchange,
+    huobi: MockExchange,
+  };
+});
+
+const createTestApp = require('../helpers/app');
+const PortalUserModel = require('../../app/models/portalUserModel');
+const PortalTokenModel = require('../../app/models/portalTokenModel');
+const DataExchangeSymbolModel = require('../../app/models/dataExchangeSymbolModel');
+
+let app;
+
+beforeAll(async () => {
+  await connect();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+afterEach(async () => {
+  await clearDatabase();
+});
+
+/**
+ * Helper: create an authenticated user with token.
+ */
+const createAuthUser = async () => {
+  const userId = new mongoose.Types.ObjectId();
+  await PortalUserModel.create({
+    _id: userId,
+    nick_name: 'SymbolTestUser',
+    email: `symbol-test-${Date.now()}@test.com`,
+    password: 'hashed',
+    salt: `salt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    seq_id: Math.floor(Math.random() * 100000),
+  });
+  const tokenDoc = await PortalTokenModel.create({
+    user_id: userId,
+    token: `symbol-token-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type: 'session',
+    last_access_time: new Date(),
+  });
+  return { userId, tokenDoc };
+};
+
+describe('Symbol API Integration', () => {
+  describe('GET /api/v1/symbols', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).get('/api/v1/symbols');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return list of symbols', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      // Seed symbols with unique on_time values
+      await DataExchangeSymbolModel.create([
+        {
+          key: 'binance_BTC/USDT',
+          exchange: 'binance',
+          symbol: 'BTC/USDT',
+          base: 'BTC',
+          quote: 'USDT',
+          price_usd: '50000',
+          on_time: new Date('2025-01-01T00:00:00Z'),
+        },
+        {
+          key: 'binance_ETH/USDT',
+          exchange: 'binance',
+          symbol: 'ETH/USDT',
+          base: 'ETH',
+          quote: 'USDT',
+          price_usd: '3000',
+          on_time: new Date('2025-01-02T00:00:00Z'),
+        },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/symbols')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toHaveLength(2);
+      expect(res.body.data).toHaveProperty('total', 2);
+    });
+
+    it('should filter symbols by exchange query param', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      await DataExchangeSymbolModel.create([
+        {
+          key: 'binance_BTC/USDT',
+          exchange: 'binance',
+          symbol: 'BTC/USDT',
+          base: 'BTC',
+          quote: 'USDT',
+          on_time: new Date('2025-02-01T00:00:00Z'),
+        },
+        {
+          key: 'okx_BTC/USDT',
+          exchange: 'okx',
+          symbol: 'BTC/USDT',
+          base: 'BTC',
+          quote: 'USDT',
+          on_time: new Date('2025-02-02T00:00:00Z'),
+        },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/symbols?exchange=binance')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.list).toHaveLength(1);
+      expect(res.body.data.list[0].exchange).toBe('binance');
+    });
+  });
+
+  describe('GET /api/v1/symbols/:id', () => {
+    it('should return a symbol by ID', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const symbol = await DataExchangeSymbolModel.create({
+        key: 'binance_BTC/USDT',
+        exchange: 'binance',
+        symbol: 'BTC/USDT',
+        base: 'BTC',
+        quote: 'USDT',
+        price_usd: '50000',
+        on_time: new Date('2025-03-01T00:00:00Z'),
+      });
+
+      const res = await request(app)
+        .get(`/api/v1/symbols/${symbol._id}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.exchange).toBe('binance');
+      expect(res.body.data.symbol).toBe('BTC/USDT');
+    });
+
+    it('should return null data for non-existent symbol', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .get(`/api/v1/symbols/${fakeId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      // The service returns null for non-existent symbol (no CustomError thrown)
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeNull();
+    });
+  });
+
+  describe('POST /api/v1/symbols', () => {
+    it('should create a new symbol', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .post('/api/v1/symbols')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({
+          key: 'binance_SOL/USDT',
+          exchange: 'binance',
+          symbol: 'SOL/USDT',
+          base: 'SOL',
+          quote: 'USDT',
+          price_usd: '100',
+          on_time: new Date('2025-04-01T00:00:00Z').toISOString(),
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data).toHaveProperty('newExchangeSymbol');
+      expect(res.body.data.newExchangeSymbol).toHaveProperty('_id');
+
+      // Verify in DB
+      const created = await DataExchangeSymbolModel.findById(
+        res.body.data.newExchangeSymbol._id
+      ).lean();
+      expect(created).not.toBeNull();
+      expect(created.symbol).toBe('SOL/USDT');
+    });
+
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).post('/api/v1/symbols').send({
+        exchange: 'binance',
+        symbol: 'SOL/USDT',
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/tests/integration/user.test.js
+++ b/tests/integration/user.test.js
@@ -1,0 +1,344 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { connect, closeDatabase, clearDatabase } = require('../helpers/db');
+
+// Mock email service to avoid sending real emails
+jest.mock('../../app/services/emailService', () => ({
+  sendEmail: jest.fn().mockResolvedValue({ emailStatus: 1 }),
+}));
+
+// Mock logger to reduce noise
+jest.mock('../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  stream: { write: jest.fn() },
+}));
+
+const createTestApp = require('../helpers/app');
+const PortalUserModel = require('../../app/models/portalUserModel');
+const PortalTokenModel = require('../../app/models/portalTokenModel');
+const PortalRoleModel = require('../../app/models/portalRoleModel');
+const UserService = require('../../app/services/userService');
+
+let app;
+
+beforeAll(async () => {
+  await connect();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+afterEach(async () => {
+  await clearDatabase();
+});
+
+/**
+ * Helper: create a regular authenticated user.
+ */
+const createAuthUser = async (overrides = {}) => {
+  const userId = new mongoose.Types.ObjectId();
+  const seqId = overrides.seq_id || Math.floor(Math.random() * 100000);
+  const user = await PortalUserModel.create({
+    nick_name: overrides.nick_name || 'TestUser',
+    email: overrides.email || `user-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`,
+    password: 'hashed',
+    salt: `salt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    seq_id: seqId,
+    invitation_code: overrides.invitation_code || 'ABC123',
+    ...overrides,
+    _id: userId,
+  });
+  const tokenDoc = await PortalTokenModel.create({
+    user_id: userId,
+    token: `user-token-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type: 'session',
+    last_access_time: new Date(),
+  });
+  return { userId, user, tokenDoc, seqId };
+};
+
+/**
+ * Helper: create an admin user with admin role.
+ */
+const createAdminUser = async () => {
+  const adminRole = await PortalRoleModel.create({
+    role_name: 'admin',
+    role_description: 'Administrator',
+    resource: [],
+  });
+
+  const userId = new mongoose.Types.ObjectId();
+  const seqId = Math.floor(Math.random() * 100000);
+  const user = await PortalUserModel.create({
+    _id: userId,
+    nick_name: 'AdminUser',
+    email: `admin-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`,
+    password: 'hashed',
+    salt: `salt-admin-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    seq_id: seqId,
+    role: adminRole._id,
+  });
+  const tokenDoc = await PortalTokenModel.create({
+    user_id: userId,
+    token: `admin-token-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type: 'session',
+    last_access_time: new Date(),
+  });
+  return { userId, user, tokenDoc, seqId };
+};
+
+describe('User API Integration', () => {
+  describe('GET /api/v1/users', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).get('/api/v1/users');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .get('/api/v1/users')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return list of users for admin', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+
+      // Create additional users
+      await createAuthUser({ nick_name: 'User1' });
+      await createAuthUser({ nick_name: 'User2' });
+
+      const res = await request(app)
+        .get('/api/v1/users')
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list.length).toBeGreaterThanOrEqual(3); // admin + 2 users
+      expect(res.body.data).toHaveProperty('total');
+      // Should not include password or salt
+      res.body.data.list.forEach((user) => {
+        expect(user).not.toHaveProperty('password');
+        expect(user).not.toHaveProperty('salt');
+      });
+    });
+  });
+
+  describe('GET /api/v1/users/profile', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).get('/api/v1/users/profile');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return current user profile', async () => {
+      const { userId, tokenDoc, seqId } = await createAuthUser({
+        nick_name: 'ProfileUser',
+      });
+
+      const res = await request(app)
+        .get('/api/v1/users/profile')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.nick_name).toBe('ProfileUser');
+      expect(res.body.data).not.toHaveProperty('password');
+      expect(res.body.data).not.toHaveProperty('salt');
+      // Should have ref_code generated from seq_id
+      expect(res.body.data).toHaveProperty('ref_code');
+    });
+  });
+
+  describe('GET /api/v1/users/invitations', () => {
+    it('should return 401 when no auth headers provided', async () => {
+      const res = await request(app).get('/api/v1/users/invitations');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return empty list when user has no invitees', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      const res = await request(app)
+        .get('/api/v1/users/invitations')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.list).toEqual([]);
+      expect(res.body.data.total).toBe(0);
+    });
+
+    it('should return list of invited users', async () => {
+      const { userId, tokenDoc } = await createAuthUser();
+
+      // Create users that were invited by this user
+      await PortalUserModel.create([
+        {
+          nick_name: 'Invitee1',
+          email: `invitee1-${Date.now()}@test.com`,
+          password: 'hashed',
+          salt: `salt-inv1-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          seq_id: Math.floor(Math.random() * 100000),
+          inviter: userId,
+        },
+        {
+          nick_name: 'Invitee2',
+          email: `invitee2-${Date.now()}@test.com`,
+          password: 'hashed',
+          salt: `salt-inv2-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          seq_id: Math.floor(Math.random() * 100000),
+          inviter: userId,
+        },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/users/invitations')
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.list).toHaveLength(2);
+      expect(res.body.data.total).toBe(2);
+    });
+  });
+
+  describe('GET /api/v1/users/:id', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc, seqId } = await createAuthUser();
+
+      const res = await request(app)
+        .get(`/api/v1/users/${seqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return user by seq_id for admin', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+      const { seqId } = await createAuthUser({ nick_name: 'TargetUser' });
+
+      const res = await request(app)
+        .get(`/api/v1/users/${seqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.nick_name).toBe('TargetUser');
+      expect(res.body.data).not.toHaveProperty('password');
+    });
+
+    it('should return error for non-existent user', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+
+      const res = await request(app)
+        .get('/api/v1/users/999999')
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('PATCH /api/v1/users/:id', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc, seqId } = await createAuthUser();
+
+      const res = await request(app)
+        .patch(`/api/v1/users/${seqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString())
+        .send({ nick_name: 'Updated' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should update user info for admin', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+      const { seqId } = await createAuthUser({ nick_name: 'BeforeUpdate' });
+
+      const res = await request(app)
+        .patch(`/api/v1/users/${seqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString())
+        .send({ nick_name: 'AfterUpdate' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data.nick_name).toBe('AfterUpdate');
+      expect(res.body.data).not.toHaveProperty('password');
+    });
+
+    it('should return error for non-existent user', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+
+      const res = await request(app)
+        .patch('/api/v1/users/999999')
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString())
+        .send({ nick_name: 'NoUser' });
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('DELETE /api/v1/users/:id', () => {
+    it('should return 403 for non-admin user', async () => {
+      const { userId, tokenDoc, seqId } = await createAuthUser();
+
+      const res = await request(app)
+        .delete(`/api/v1/users/${seqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', userId.toString());
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should soft delete user for admin (when admin is the user)', async () => {
+      const { userId: adminId, tokenDoc, seqId: adminSeqId } = await createAdminUser();
+
+      // The deleteUser service checks user._id == requestUserId
+      // Admin deleting their own account should work
+      const res = await request(app)
+        .delete(`/api/v1/users/${adminSeqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe(0);
+      expect(res.body.data).toHaveProperty('seq_id');
+
+      // Verify soft delete in DB
+      const deleted = await PortalUserModel.findById(adminId).lean();
+      expect(deleted.is_deleted).toBe(true);
+    });
+
+    it('should return 403 when admin tries to delete another user', async () => {
+      const { userId: adminId, tokenDoc } = await createAdminUser();
+      const { seqId: targetSeqId } = await createAuthUser();
+
+      // deleteUser checks user._id.toString() !== requestUserId → 403
+      const res = await request(app)
+        .delete(`/api/v1/users/${targetSeqId}`)
+        .set('token', tokenDoc.token)
+        .set('user_id', adminId.toString());
+
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/tests/unit/services/commonConfigService.test.js
+++ b/tests/unit/services/commonConfigService.test.js
@@ -1,0 +1,108 @@
+jest.mock('../../../app/models/commonConfigModel');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const CommonConfigModel = require('../../../app/models/commonConfigModel');
+const CommonConfigService = require('../../../app/services/commonConfigService');
+
+describe('CommonConfigService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getNextSequenceValue()', () => {
+    it('should return incremented sequence value', async () => {
+      CommonConfigModel.findOneAndUpdate.mockResolvedValue({
+        sequence_value: 10,
+      });
+
+      const result = await CommonConfigService.getNextSequenceValue();
+
+      expect(CommonConfigModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { name: 'auto_user_id' },
+        { $inc: { sequence_value: 1 } },
+        { new: true, select: 'sequence_value' }
+      );
+      expect(result).toBe(10);
+    });
+  });
+
+  describe('getGiveToken()', () => {
+    it('should return token content when found', async () => {
+      CommonConfigModel.findOne.mockResolvedValue({ name: 'give_token', content: 5 });
+
+      const result = await CommonConfigService.getGiveToken();
+
+      expect(CommonConfigModel.findOne).toHaveBeenCalledWith({ name: 'give_token' });
+      expect(result).toBe(5);
+    });
+
+    it('should return undefined when not found', async () => {
+      CommonConfigModel.findOne.mockResolvedValue(null);
+
+      const result = await CommonConfigService.getGiveToken();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getDingTouId()', () => {
+    it('should return dingtou id content when found', async () => {
+      CommonConfigModel.findOne.mockResolvedValue({ name: 'dingtou_id', content: 'abc-123' });
+
+      const result = await CommonConfigService.getDingTouId();
+
+      expect(CommonConfigModel.findOne).toHaveBeenCalledWith({ name: 'dingtou_id' });
+      expect(result).toBe('abc-123');
+    });
+
+    it('should return 0 when not found', async () => {
+      CommonConfigModel.findOne.mockResolvedValue(null);
+
+      const result = await CommonConfigService.getDingTouId();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('getAccessToken()', () => {
+    it('should return access token when found', async () => {
+      CommonConfigModel.findOne.mockResolvedValue({
+        name: 'access_token',
+        content: 'my-token-123',
+      });
+
+      const result = await CommonConfigService.getAccessToken();
+
+      expect(CommonConfigModel.findOne).toHaveBeenCalledWith({ name: 'access_token' });
+      expect(result).toBe('my-token-123');
+    });
+
+    it('should return null when not found', async () => {
+      CommonConfigModel.findOne.mockResolvedValue(null);
+
+      const result = await CommonConfigService.getAccessToken();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setAccessToken()', () => {
+    it('should update and return the access token document', async () => {
+      const updatedDoc = { name: 'access_token', content: 'new-token-456' };
+      CommonConfigModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+
+      const result = await CommonConfigService.setAccessToken('new-token-456');
+
+      expect(CommonConfigModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { name: 'access_token' },
+        { content: 'new-token-456' },
+        { new: true }
+      );
+      expect(result).toEqual(updatedDoc);
+    });
+  });
+});

--- a/tests/unit/services/emailService.test.js
+++ b/tests/unit/services/emailService.test.js
@@ -1,0 +1,191 @@
+jest.mock('nodemailer');
+jest.mock('../../../app/models/portalEmailInfoModel');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const nodemailer = require('nodemailer');
+const PortalEmailInfoModel = require('../../../app/models/portalEmailInfoModel');
+
+// Set model statics before requiring the service
+PortalEmailInfoModel.STATUS_FAILED = 0;
+PortalEmailInfoModel.STATUS_SUCCESS = 1;
+PortalEmailInfoModel.SEND_MARK_ALREADY_SENT = 0;
+PortalEmailInfoModel.SEND_MARK_WAIT_TO_SEND = 1;
+
+// Setup nodemailer mock transport before requiring the service
+const mockSendMail = jest.fn();
+nodemailer.createTransport.mockReturnValue({
+  sendMail: mockSendMail,
+});
+
+const EmailService = require('../../../app/services/emailService');
+
+describe('EmailService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-setup sendMail mock since clearAllMocks resets it
+    mockSendMail.mockReset();
+  });
+
+  describe('sendEmail()', () => {
+    it('should save email info and send synchronously when async is false', async () => {
+      const mockEmailDoc = {
+        _id: 'email-doc-1',
+        save: jest.fn().mockResolvedValue({ _id: 'email-doc-1' }),
+      };
+      PortalEmailInfoModel.mockImplementation(() => mockEmailDoc);
+
+      mockSendMail.mockResolvedValue({
+        accepted: ['test@example.com'],
+        rejected: [],
+        envelope: { from: 'no-reply@moow.cc', to: ['test@example.com'] },
+        response: '250 OK',
+        messageId: 'msg-1',
+      });
+      PortalEmailInfoModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(true),
+      });
+
+      const params = {
+        async: false,
+        to: 'test@example.com',
+        subject: 'Test Subject',
+        text: 'Hello',
+        html: '<p>Hello</p>',
+      };
+
+      const result = await EmailService.sendEmail(params);
+
+      expect(mockEmailDoc.save).toHaveBeenCalled();
+      expect(mockSendMail).toHaveBeenCalled();
+      expect(result.emailStatus).toBe(PortalEmailInfoModel.STATUS_SUCCESS);
+      expect(result.async).toBe(false);
+    });
+
+    it('should save email info but not send when async is true', async () => {
+      const mockEmailDoc = {
+        _id: 'email-doc-2',
+        save: jest.fn().mockResolvedValue({ _id: 'email-doc-2' }),
+      };
+      PortalEmailInfoModel.mockImplementation(() => mockEmailDoc);
+
+      const params = {
+        async: true,
+        to: 'test@example.com',
+        subject: 'Test Subject',
+        text: 'Hello',
+        html: '<p>Hello</p>',
+      };
+
+      const result = await EmailService.sendEmail(params);
+
+      expect(mockEmailDoc.save).toHaveBeenCalled();
+      expect(mockSendMail).not.toHaveBeenCalled();
+      expect(result.emailStatus).toBe(PortalEmailInfoModel.STATUS_FAILED);
+      expect(result.async).toBe(true);
+    });
+  });
+
+  describe('sendAlarmMail()', () => {
+    it('should send alarm email with correct params', async () => {
+      const mockEmailDoc = {
+        _id: 'email-doc-3',
+        save: jest.fn().mockResolvedValue({ _id: 'email-doc-3' }),
+      };
+      PortalEmailInfoModel.mockImplementation(() => mockEmailDoc);
+
+      mockSendMail.mockResolvedValue({
+        accepted: ['alarm@moow.cc'],
+        rejected: [],
+        envelope: {},
+        response: '250 OK',
+        messageId: 'msg-alarm',
+      });
+      PortalEmailInfoModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(true),
+      });
+
+      // Need to set config.alarm.mailto
+      const config = require('../../../config');
+      config.alarm = { mailto: ['alarm@moow.cc'] };
+
+      jest.spyOn(EmailService, 'sendEmail');
+
+      await EmailService.sendAlarmMail('Alert Subject', 'Something went wrong');
+
+      expect(EmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          async: false,
+          to: ['alarm@moow.cc'],
+          subject: 'Alert Subject',
+          text: 'Something went wrong',
+          html: '<p>Something went wrong</p>',
+        })
+      );
+    });
+
+    it('should return early when mailto is empty', async () => {
+      const config = require('../../../config');
+      config.alarm = { mailto: [] };
+
+      jest.spyOn(EmailService, 'sendEmail');
+
+      await EmailService.sendAlarmMail('Alert', 'message');
+
+      expect(EmailService.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('send()', () => {
+    it('should handle transporter errors gracefully', async () => {
+      mockSendMail.mockRejectedValue(new Error('SMTP connection failed'));
+
+      const params = {
+        to: 'test@example.com',
+        subject: 'Test',
+        text: 'Hello',
+        html: '<p>Hello</p>',
+      };
+
+      const result = await EmailService.send(params);
+
+      expect(result.emailStatus).toBe(PortalEmailInfoModel.STATUS_FAILED);
+      expect(result.desc).toBeInstanceOf(Error);
+    });
+
+    it('should send email with attachments', async () => {
+      mockSendMail.mockResolvedValue({
+        accepted: ['test@example.com'],
+        rejected: [],
+        envelope: {},
+        response: '250 OK',
+        messageId: 'msg-2',
+      });
+
+      const params = {
+        _emailId: 'email-doc-4',
+        to: 'test@example.com',
+        subject: 'With Attachment',
+        text: 'See attached',
+        html: '<p>See attached</p>',
+        attachments: [{ filename: 'report.pdf', content: 'base64content' }],
+      };
+
+      PortalEmailInfoModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(true),
+      });
+
+      const result = await EmailService.send(params);
+
+      expect(result.emailStatus).toBe(PortalEmailInfoModel.STATUS_SUCCESS);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [{ filename: 'report.pdf', content: 'base64content', encoding: 'base64' }],
+        })
+      );
+    });
+  });
+});

--- a/tests/unit/services/marketService.test.js
+++ b/tests/unit/services/marketService.test.js
@@ -1,0 +1,174 @@
+jest.mock('../../../app/models/portalMarketModel');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const PortalMarketModel = require('../../../app/models/portalMarketModel');
+const MarketService = require('../../../app/services/marketService');
+const CustomError = require('../../../app/utils/customError');
+
+describe('MarketService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllMarkets()', () => {
+    it('should return paginated list of markets', async () => {
+      const mockMarkets = [
+        { _id: 'market-1', name: 'Binance', exchange: 'binance' },
+        { _id: 'market-2', name: 'OKX', exchange: 'okx' },
+      ];
+
+      PortalMarketModel.find.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          skip: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue(mockMarkets),
+            }),
+          }),
+        }),
+      });
+      // countDocuments is chained on a second find() call
+      PortalMarketModel.find.mockReturnValueOnce({
+        sort: jest.fn().mockReturnValue({
+          skip: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue(mockMarkets),
+            }),
+          }),
+        }),
+      });
+      PortalMarketModel.find.mockReturnValueOnce({
+        countDocuments: jest.fn().mockResolvedValue(2),
+      });
+
+      const result = await MarketService.getAllMarkets({ pageNumber: 1, pageSize: 10 });
+
+      expect(result.list).toEqual(mockMarkets);
+      expect(result.pageNumber).toBe(1);
+      expect(result.pageSize).toBe(10);
+      expect(result.total).toBe(2);
+    });
+
+    it('should apply keyword search filter', async () => {
+      PortalMarketModel.find.mockReturnValueOnce({
+        sort: jest.fn().mockReturnValue({
+          skip: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      });
+      PortalMarketModel.find.mockReturnValueOnce({
+        countDocuments: jest.fn().mockResolvedValue(0),
+      });
+
+      await MarketService.getAllMarkets({ keyword: 'binance' });
+
+      // First call should have $or condition with regex
+      const firstCallConditions = PortalMarketModel.find.mock.calls[0][0];
+      expect(firstCallConditions).toHaveProperty('$or');
+      expect(firstCallConditions.$or).toHaveLength(2);
+    });
+  });
+
+  describe('getMarketById()', () => {
+    it('should return market when found', async () => {
+      const mockMarket = { _id: 'market-1', name: 'Binance', exchange: 'binance' };
+      PortalMarketModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockMarket),
+      });
+
+      const result = await MarketService.getMarketById('market-1');
+
+      expect(result).toEqual(mockMarket);
+      expect(PortalMarketModel.findById).toHaveBeenCalledWith('market-1');
+    });
+
+    it('should throw CustomError when market not found', async () => {
+      PortalMarketModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(MarketService.getMarketById('nonexistent')).rejects.toThrow(CustomError);
+    });
+  });
+
+  describe('createMarket()', () => {
+    it('should create and save a new market', async () => {
+      const mockSave = jest.fn().mockResolvedValue({ _id: 'new-market-id' });
+      PortalMarketModel.mockImplementation(() => ({
+        _id: 'new-market-id',
+        save: mockSave,
+      }));
+
+      const result = await MarketService.createMarket({
+        name: 'Binance',
+        exchange: 'binance',
+        url: 'https://binance.com',
+      });
+
+      expect(mockSave).toHaveBeenCalled();
+      expect(result._id).toBe('new-market-id');
+    });
+  });
+
+  describe('updateMarket()', () => {
+    it('should update market fields and save', async () => {
+      const mockDoc = {
+        _id: 'market-1',
+        name: 'Old Name',
+        exchange: 'old-exchange',
+        url: 'https://old.com',
+        save: jest.fn().mockResolvedValue(true),
+      };
+      PortalMarketModel.findById.mockResolvedValue(mockDoc);
+
+      const result = await MarketService.updateMarket('market-1', {
+        name: 'New Name',
+        exchange: 'new-exchange',
+        url: 'https://new.com',
+      });
+
+      expect(mockDoc.name).toBe('New Name');
+      expect(mockDoc.exchange).toBe('new-exchange');
+      expect(mockDoc.url).toBe('https://new.com');
+      expect(mockDoc.save).toHaveBeenCalled();
+      expect(result._id).toBe('market-1');
+    });
+
+    it('should throw CustomError when market not found', async () => {
+      PortalMarketModel.findById.mockResolvedValue(null);
+
+      await expect(MarketService.updateMarket('nonexistent', { name: 'Test' })).rejects.toThrow(
+        CustomError
+      );
+    });
+  });
+
+  describe('deleteMarket()', () => {
+    it('should soft delete market by setting is_deleted to true', async () => {
+      const mockDoc = {
+        _id: 'market-1',
+        is_deleted: false,
+        save: jest.fn().mockResolvedValue(true),
+      };
+      PortalMarketModel.findById.mockResolvedValue(mockDoc);
+
+      const result = await MarketService.deleteMarket('market-1');
+
+      expect(mockDoc.is_deleted).toBe(true);
+      expect(mockDoc.save).toHaveBeenCalled();
+      expect(result._id).toBe('market-1');
+    });
+
+    it('should throw CustomError when market not found', async () => {
+      PortalMarketModel.findById.mockResolvedValue(null);
+
+      await expect(MarketService.deleteMarket('nonexistent')).rejects.toThrow(CustomError);
+    });
+  });
+});

--- a/tests/unit/services/sequenceService.test.js
+++ b/tests/unit/services/sequenceService.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../../app/models/commonSequenceCounterModel');
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const CommonSequenceCounterModel = require('../../../app/models/commonSequenceCounterModel');
+const SequenceService = require('../../../app/services/sequenceService');
+
+describe('SequenceService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getNextSequenceValue()', () => {
+    it('should return incremented sequence value', async () => {
+      CommonSequenceCounterModel.findOneAndUpdate.mockResolvedValue({
+        sequence_value: 42,
+      });
+
+      const result = await SequenceService.getNextSequenceValue('portal_user');
+
+      expect(CommonSequenceCounterModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { sequence_name: 'portal_user' },
+        { $inc: { sequence_value: 1 } },
+        { new: true, upsert: true }
+      );
+      expect(result).toBe(42);
+    });
+
+    it('should throw when sequence document is null', async () => {
+      CommonSequenceCounterModel.findOneAndUpdate.mockResolvedValue(null);
+
+      await expect(SequenceService.getNextSequenceValue('unknown')).rejects.toThrow(
+        'Unable to fetch or create the sequence document'
+      );
+    });
+  });
+});

--- a/tests/unit/services/symbolService.test.js
+++ b/tests/unit/services/symbolService.test.js
@@ -1,0 +1,203 @@
+jest.mock('axios');
+jest.mock('ccxt');
+jest.mock('csv-parser');
+jest.mock('fs');
+jest.mock('../../../app/models/dataExchangeSymbolModel');
+jest.mock('../../../app/models/dataExchangeRateModel');
+jest.mock('../../../app/utils/cacheManager', () => ({
+  symbolCache: { get: jest.fn(), set: jest.fn() },
+  rateCache: { get: jest.fn(), set: jest.fn() },
+  priceCache: { get: jest.fn(), set: jest.fn() },
+  publicOrderCache: { get: jest.fn(), set: jest.fn() },
+}));
+jest.mock('../../../app/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const axios = require('axios');
+const DataExchangeSymbolModel = require('../../../app/models/dataExchangeSymbolModel');
+const DataExchangeRateModel = require('../../../app/models/dataExchangeRateModel');
+const { symbolCache, rateCache } = require('../../../app/utils/cacheManager');
+const SymbolService = require('../../../app/services/symbolService');
+
+describe('SymbolService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllSymbols()', () => {
+    it('should return cached result on cache hit', async () => {
+      const cachedResult = {
+        list: [{ _id: 's1', symbol: 'BTC/USDT' }],
+        pageNumber: 1,
+        pageSize: 20,
+        total: 1,
+      };
+      symbolCache.get.mockReturnValue(cachedResult);
+
+      const result = await SymbolService.getAllSymbols({ exchange: 'binance' });
+
+      expect(result).toEqual(cachedResult);
+      expect(DataExchangeSymbolModel.find).not.toHaveBeenCalled();
+    });
+
+    it('should query database on cache miss and cache the result', async () => {
+      symbolCache.get.mockReturnValue(undefined);
+
+      const mockSymbols = [{ _id: 's1', symbol: 'BTC/USDT', exchange: 'binance' }];
+      DataExchangeSymbolModel.find.mockReturnValueOnce({
+        collation: jest.fn().mockReturnValue({
+          sort: jest.fn().mockReturnValue({
+            skip: jest.fn().mockReturnValue({
+              limit: jest.fn().mockReturnValue({
+                lean: jest.fn().mockResolvedValue(mockSymbols),
+              }),
+            }),
+          }),
+        }),
+      });
+      DataExchangeSymbolModel.find.mockReturnValueOnce({
+        countDocuments: jest.fn().mockResolvedValue(1),
+      });
+
+      const result = await SymbolService.getAllSymbols({
+        exchange: 'binance',
+        pageNumber: 1,
+        pageSize: 20,
+      });
+
+      expect(result.list).toEqual(mockSymbols);
+      expect(result.pageNumber).toBe(1);
+      expect(result.pageSize).toBe(20);
+      expect(result.total).toBe(1);
+      expect(symbolCache.set).toHaveBeenCalled();
+    });
+
+    it('should apply keyword search with regex conditions', async () => {
+      symbolCache.get.mockReturnValue(undefined);
+
+      DataExchangeSymbolModel.find.mockReturnValueOnce({
+        collation: jest.fn().mockReturnValue({
+          sort: jest.fn().mockReturnValue({
+            skip: jest.fn().mockReturnValue({
+              limit: jest.fn().mockReturnValue({
+                lean: jest.fn().mockResolvedValue([]),
+              }),
+            }),
+          }),
+        }),
+      });
+      DataExchangeSymbolModel.find.mockReturnValueOnce({
+        countDocuments: jest.fn().mockResolvedValue(0),
+      });
+
+      await SymbolService.getAllSymbols({ keyword: 'BTC' });
+
+      const firstCallConditions = DataExchangeSymbolModel.find.mock.calls[0][0];
+      expect(firstCallConditions).toHaveProperty('$or');
+      expect(firstCallConditions.$or).toHaveLength(4);
+    });
+  });
+
+  describe('getSymbolById()', () => {
+    it('should return symbol when found', async () => {
+      const mockSymbol = { _id: 's1', symbol: 'BTC/USDT', exchange: 'binance' };
+      DataExchangeSymbolModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockSymbol),
+      });
+
+      const result = await SymbolService.getSymbolById('s1');
+
+      expect(result).toEqual(mockSymbol);
+      expect(DataExchangeSymbolModel.findById).toHaveBeenCalledWith('s1');
+    });
+
+    it('should return null when symbol not found', async () => {
+      DataExchangeSymbolModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await SymbolService.getSymbolById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createSymbol()', () => {
+    it('should create and save a new symbol', async () => {
+      const mockSave = jest.fn().mockResolvedValue({ _id: 'new-symbol-id' });
+      DataExchangeSymbolModel.mockImplementation(() => ({
+        _id: 'new-symbol-id',
+        save: mockSave,
+      }));
+
+      const result = await SymbolService.createSymbol({
+        exchange: 'binance',
+        symbol: 'ETH/USDT',
+        price_native: '3000',
+        base: 'USDT',
+        quote: 'ETH',
+      });
+
+      expect(mockSave).toHaveBeenCalled();
+      expect(result.newExchangeSymbol).toBeDefined();
+    });
+  });
+
+  describe('getUSDToOtherRate()', () => {
+    it('should return cached rate on cache hit', async () => {
+      rateCache.get.mockReturnValue(7.25);
+
+      const result = await SymbolService.getUSDToOtherRate('CNY');
+
+      expect(result).toBe(7.25);
+      expect(DataExchangeRateModel.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should return rate from DB when available', async () => {
+      rateCache.get.mockReturnValue(undefined);
+      DataExchangeRateModel.findOne.mockResolvedValue({
+        from_currency: 'USD',
+        to_currency: 'CNY',
+        rate: 7.2,
+      });
+
+      const result = await SymbolService.getUSDToOtherRate('CNY');
+
+      expect(result).toBe(7.2);
+      expect(rateCache.set).toHaveBeenCalledWith('rate:USD:CNY', 7.2);
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('should fetch from API when not in cache or DB', async () => {
+      rateCache.get.mockReturnValue(undefined);
+      DataExchangeRateModel.findOne.mockResolvedValue(null);
+      axios.get.mockResolvedValue({
+        data: { rates: { CNY: 7.3 } },
+      });
+      const mockSave = jest.fn().mockResolvedValue(true);
+      DataExchangeRateModel.mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      const result = await SymbolService.getUSDToOtherRate('CNY');
+
+      expect(result).toBe(7.3);
+      expect(axios.get).toHaveBeenCalled();
+      expect(mockSave).toHaveBeenCalled();
+      expect(rateCache.set).toHaveBeenCalledWith('rate:USD:CNY', 7.3);
+    });
+
+    it('should return null on API error', async () => {
+      rateCache.get.mockReturnValue(undefined);
+      DataExchangeRateModel.findOne.mockResolvedValue(null);
+      axios.get.mockRejectedValue(new Error('Network error'));
+
+      const result = await SymbolService.getUSDToOtherRate('CNY');
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Added 5 unit tests: `symbolService`, `sequenceService`, `commonConfigService`, `emailService`, `marketService`
- Added 5 integration tests: `purchase`, `user`, `symbol`, `market`, `home` API endpoints
- Fixed lint issues in generated test files (Prettier formatting, duplicate key)

## Coverage Improvement

| Metric | Before | After |
|--------|--------|-------|
| Statements | 59% | **82.7%** |
| Branches | 42% | **70.1%** |
| Functions | 41% | **71.6%** |
| Lines | — | **83.2%** |

## Test Results

- **357 tests** across 33 test suites — all passing
- **0 lint errors**, 0 warnings

## Test plan

- [x] `npm test` — 357/357 pass
- [x] `npm test -- --coverage` — 82.7% statements
- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)